### PR TITLE
Add TTS/STT provider system with ElevenLabs support

### DIFF
--- a/.docs/plans/2026.02.22-tts-stt-provider-system.md
+++ b/.docs/plans/2026.02.22-tts-stt-provider-system.md
@@ -447,7 +447,7 @@ Since postinstall no longer sets up local models, `sidecar/index.ts` must fail f
 
 ## Phases
 
-### Phase 1: Provider Interfaces and Factories
+### Phase 1: Provider Interfaces and Factories ✅
 
 1. Add new types to `sidecar/types.ts` (`TtsProviderType`, `SttProviderType`, `ProviderStatus`, `TtsProviderConfig`, `SttProviderConfig`)
 2. Rename `createTts` to `createLocalTts` in `sidecar/tts.ts`, export `bufferSentences` and `writePcm`
@@ -461,7 +461,7 @@ Since postinstall no longer sets up local models, `sidecar/index.ts` must fail f
 10. Update `sidecar/browser-server.ts`: update DEFAULT_CONFIG to use provider configs
 11. Verify existing local TTS + STT still works end-to-end
 
-### Phase 2: ElevenLabs Providers
+### Phase 2: ElevenLabs Providers ✅
 
 1. Create `sidecar/tts-elevenlabs.ts` implementing `TtsPlayer` via ElevenLabs streaming TTS API
 2. Register it in `sidecar/tts-provider.ts` factory switch
@@ -470,7 +470,7 @@ Since postinstall no longer sets up local models, `sidecar/index.ts` must fail f
 5. Test TTS with `TTS_PROVIDER=elevenlabs` in .env
 6. Test STT with `STT_PROVIDER=elevenlabs` in .env
 
-### Phase 3: On-Demand Setup
+### Phase 3: On-Demand Setup ✅
 
 1. Create `scripts/setup-local-tts.js` (extract from postinstall.js)
 2. Create `scripts/setup-local-stt.js`
@@ -479,7 +479,7 @@ Since postinstall no longer sets up local models, `sidecar/index.ts` must fail f
 5. Mount routes in `dashboard/server.ts`
 6. Add `ELEVENLABS_API_KEY` to masked keys in `dashboard/routes/settings.ts`
 
-### Phase 4: Dashboard UI
+### Phase 4: Dashboard UI ✅
 
 1. Create `dashboard/src/components/VoiceProvidersPanel.tsx`
 2. Add "Voice" tab to `dashboard/src/pages/Settings.tsx` (add to tab union type, button, and conditional render)

--- a/dashboard/routes/providers.ts
+++ b/dashboard/routes/providers.ts
@@ -1,0 +1,204 @@
+/**
+ * Provider status and on-demand setup API routes.
+ *
+ * Exposes TTS/STT provider information, readiness status, and triggers
+ * for on-demand local model installation from the dashboard:
+ * - GET /tts -- list TTS providers with status
+ * - GET /tts/status/:type -- check a specific TTS provider
+ * - GET /stt -- list STT providers with status
+ * - GET /stt/status/:type -- check a specific STT provider
+ * - POST /setup/local-tts -- trigger local TTS setup (background job)
+ * - POST /setup/local-stt -- trigger local STT setup (background job)
+ * - GET /setup/status/:jobId -- poll setup job progress and logs
+ */
+
+import { spawn } from "child_process";
+import { createWriteStream } from "fs";
+import { readFile } from "fs/promises";
+import { randomUUID } from "crypto";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { Hono } from "hono";
+
+import { getAvailableTtsProviders, getTtsProviderStatus } from "../../sidecar/tts-provider.js";
+import { getAvailableSttProviders, getSttProviderStatus } from "../../sidecar/stt-provider.js";
+import { readEnv } from "../../services/env.js";
+
+import type { TtsProviderType } from "../../sidecar/types.js";
+import type { SttProviderType } from "../../sidecar/types.js";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+/** Tracks a background setup job */
+interface SetupJob {
+  /** Whether the child process is still running */
+  running: boolean;
+  /** Child process exit code (null while running) */
+  exitCode: number | null;
+  /** Path to the log file capturing stdout + stderr */
+  logFile: string;
+}
+
+// ============================================================================
+// STATE
+// ============================================================================
+
+/** Active and completed setup jobs keyed by job ID */
+const setupJobs = new Map<string, SetupJob>();
+
+// ============================================================================
+// ROUTES
+// ============================================================================
+
+/**
+ * Create Hono route group for provider status and setup operations.
+ *
+ * @returns Hono instance with TTS/STT status and setup routes
+ */
+export function providersRoutes(): Hono {
+  const app = new Hono();
+
+  // ---- TTS routes ----
+
+  /** List all TTS providers with their current status */
+  app.get("/tts", async (c) => {
+    const providers = getAvailableTtsProviders();
+    const env = await readEnv();
+    const active = env.TTS_PROVIDER || "local";
+
+    const providersWithStatus = await Promise.all(
+      providers.map(async (p) => ({
+        ...p,
+        status: await getTtsProviderStatus(p.type),
+      }))
+    );
+
+    return c.json({ providers: providersWithStatus, active });
+  });
+
+  /** Check readiness of a specific TTS provider */
+  app.get("/tts/status/:type", async (c) => {
+    const type = c.req.param("type") as TtsProviderType;
+    const status = await getTtsProviderStatus(type);
+    return c.json(status);
+  });
+
+  // ---- STT routes ----
+
+  /** List all STT providers with their current status */
+  app.get("/stt", async (c) => {
+    const providers = getAvailableSttProviders();
+    const env = await readEnv();
+    const active = env.STT_PROVIDER || "local";
+
+    const providersWithStatus = await Promise.all(
+      providers.map(async (p) => ({
+        ...p,
+        status: await getSttProviderStatus(p.type),
+      }))
+    );
+
+    return c.json({ providers: providersWithStatus, active });
+  });
+
+  /** Check readiness of a specific STT provider */
+  app.get("/stt/status/:type", async (c) => {
+    const type = c.req.param("type") as SttProviderType;
+    const status = await getSttProviderStatus(type);
+    return c.json(status);
+  });
+
+  // ---- Setup routes ----
+
+  /** Trigger local TTS setup as a background job */
+  app.post("/setup/local-tts", async (c) => {
+    const jobId = startSetupJob("local-tts");
+    return c.json({ jobId });
+  });
+
+  /** Trigger local STT setup as a background job */
+  app.post("/setup/local-stt", async (c) => {
+    const jobId = startSetupJob("local-stt");
+    return c.json({ jobId });
+  });
+
+  /** Poll a setup job for progress and log output */
+  app.get("/setup/status/:jobId", async (c) => {
+    const jobId = c.req.param("jobId");
+    const job = setupJobs.get(jobId);
+
+    if (!job) {
+      return c.json({ error: "Unknown job ID" }, 404);
+    }
+
+    const log = await readFile(job.logFile, "utf-8").catch(() => "");
+
+    return c.json({
+      running: job.running,
+      exitCode: job.exitCode,
+      log,
+    });
+  });
+
+  return app;
+}
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/**
+ * Spawn a background child process to run a setup script.
+ * Captures stdout + stderr to a temp log file for polling.
+ *
+ * @param target - Which setup to run ("local-tts" or "local-stt")
+ * @returns The job ID for polling status
+ */
+function startSetupJob(target: "local-tts" | "local-stt"): string {
+  const jobId = randomUUID();
+  const logFile = join(tmpdir(), `voicecc-setup-${jobId}.log`);
+  const logStream = createWriteStream(logFile);
+
+  // Build the inline script that imports and runs the setup function
+  const scriptPath = target === "local-tts"
+    ? "./scripts/setup-local-tts.js"
+    : "./scripts/setup-local-stt.js";
+  const fnName = target === "local-tts" ? "setupLocalTts" : "setupLocalStt";
+  const inlineScript = `import('${scriptPath}').then(m => m.${fnName}()).catch(e => { console.error(e.message); process.exit(1); })`;
+
+  const child = spawn("node", ["--input-type=module", "-e", inlineScript], {
+    stdio: ["ignore", "pipe", "pipe"],
+    cwd: process.cwd(),
+  });
+
+  const job: SetupJob = { running: true, exitCode: null, logFile };
+  setupJobs.set(jobId, job);
+
+  // Pipe both stdout and stderr to the log file
+  child.stdout.pipe(logStream, { end: false });
+  child.stderr.pipe(logStream, { end: false });
+
+  child.on("close", (code) => {
+    const exitCode = code ?? 1;
+    const doneMsg = exitCode === 0
+      ? `\n[setup] Completed successfully.\n`
+      : `\n[setup] Failed with exit code ${exitCode}.\n`;
+    logStream.write(doneMsg);
+    logStream.end();
+
+    job.running = false;
+    job.exitCode = exitCode;
+  });
+
+  child.on("error", (err) => {
+    logStream.write(`\n[setup] Process error: ${err.message}\n`);
+    logStream.end();
+    job.running = false;
+    job.exitCode = 1;
+  });
+
+  return jobId;
+}

--- a/dashboard/routes/settings.ts
+++ b/dashboard/routes/settings.ts
@@ -14,7 +14,7 @@ import { readEnv, writeEnvFile } from "../../services/env.js";
 // ============================================================================
 
 /** Keys that should be masked when reading settings */
-const MASKED_KEYS = ["TWILIO_AUTH_TOKEN", "TWILIO_API_KEY_SECRET"];
+const MASKED_KEYS = ["TWILIO_AUTH_TOKEN", "TWILIO_API_KEY_SECRET", "ELEVENLABS_API_KEY"];
 
 // ============================================================================
 // ROUTES

--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -26,6 +26,7 @@ import { webrtcRoutes } from "./routes/webrtc.js";
 import { mcpServersRoutes } from "./routes/mcp-servers.js";
 import { authRoutes } from "./routes/auth.js";
 import { integrationsRoutes, setDashboardPort as setIntegrationsDashboardPort } from "./routes/integrations.js";
+import { providersRoutes } from "./routes/providers.js";
 import { loadDeviceTokens } from "../services/device-pairing.js";
 
 // ============================================================================
@@ -59,6 +60,7 @@ function createApp(): Hono {
   app.route("/api/mcp-servers", mcpServersRoutes());
   app.route("/api/auth", authRoutes());
   app.route("/api/integrations", integrationsRoutes());
+  app.route("/api/providers", providersRoutes());
 
   // Status endpoint (user CLAUDE.md conflict check)
   app.get("/api/status", async (c) => {

--- a/dashboard/src/components/VoiceProvidersPanel.tsx
+++ b/dashboard/src/components/VoiceProvidersPanel.tsx
@@ -1,0 +1,694 @@
+/**
+ * Voice provider selection and status panel.
+ *
+ * Allows users to:
+ * - Select TTS and STT providers via radio buttons
+ * - See provider readiness status (Ready / Not Installed / Missing API Key / Unsupported Platform)
+ * - Trigger on-demand setup for local providers (modal with live log output)
+ * - Configure ElevenLabs API key and model settings (modal)
+ * - Save all provider settings to .env
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { get, post } from "../api";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const DEFAULT_VOICE_ID = "JBFqnCBsd6RMkjVDRZzb";
+const DEFAULT_MODEL_ID = "eleven_turbo_v2_5";
+const DEFAULT_STT_MODEL_ID = "scribe_v1";
+
+/** How often to poll for setup log updates (ms) */
+const SETUP_POLL_INTERVAL_MS = 1500;
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+interface ProviderStatus {
+  ready: boolean;
+  reason?: "not_installed" | "missing_api_key" | "unsupported_platform";
+  detail?: string;
+}
+
+interface ProviderInfo {
+  type: string;
+  name: string;
+  description: string;
+  status: ProviderStatus;
+}
+
+interface ProvidersResponse {
+  providers: ProviderInfo[];
+  active: string;
+}
+
+interface SetupJobStatus {
+  running: boolean;
+  exitCode: number | null;
+  log: string;
+}
+
+type ModalState =
+  | null
+  | { kind: "setup"; target: "local-tts" | "local-stt" }
+  | { kind: "elevenlabs-tts" }
+  | { kind: "elevenlabs-stt" };
+
+// ============================================================================
+// EVENT HANDLERS
+// ============================================================================
+
+/** Fetch TTS providers list with status from the API */
+async function fetchTtsProviders(): Promise<ProvidersResponse> {
+  return get<ProvidersResponse>("/api/providers/tts");
+}
+
+/** Fetch STT providers list with status from the API */
+async function fetchSttProviders(): Promise<ProvidersResponse> {
+  return get<ProvidersResponse>("/api/providers/stt");
+}
+
+/** Fetch current settings from .env */
+async function fetchSettings(): Promise<Record<string, string>> {
+  return get<Record<string, string>>("/api/settings");
+}
+
+// ============================================================================
+// COMPONENTS
+// ============================================================================
+
+/** Color-coded badge showing provider readiness */
+function StatusBadge({ status }: { status: ProviderStatus }) {
+  let label: string;
+  let bgColor: string;
+  let textColor: string;
+
+  if (status.ready) {
+    label = "Ready";
+    bgColor = "rgba(34, 197, 94, 0.15)";
+    textColor = "#22c55e";
+  } else if (status.reason === "not_installed") {
+    label = "Not Installed";
+    bgColor = "rgba(234, 179, 8, 0.15)";
+    textColor = "#eab308";
+  } else if (status.reason === "missing_api_key") {
+    label = "Missing API Key";
+    bgColor = "rgba(239, 68, 68, 0.15)";
+    textColor = "#ef4444";
+  } else if (status.reason === "unsupported_platform") {
+    label = "Unsupported Platform";
+    bgColor = "rgba(156, 163, 175, 0.15)";
+    textColor = "#9ca3af";
+  } else {
+    label = "Unknown";
+    bgColor = "rgba(156, 163, 175, 0.15)";
+    textColor = "#9ca3af";
+  }
+
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        padding: "2px 8px",
+        borderRadius: "4px",
+        fontSize: "11px",
+        fontWeight: 600,
+        background: bgColor,
+        color: textColor,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+/** Single provider row with radio button, name, description, status badge, and action button */
+function ProviderRow({
+  provider,
+  selected,
+  onSelect,
+  onAction,
+  actionLabel,
+  actionDisabled,
+}: {
+  provider: ProviderInfo;
+  selected: boolean;
+  onSelect: () => void;
+  onAction?: () => void;
+  actionLabel?: string;
+  actionDisabled?: boolean;
+}) {
+  const disabled = !provider.status.ready;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "10px",
+        padding: "10px 12px",
+        border: selected ? "1px solid var(--btn-primary-bg)" : "1px solid var(--border-color)",
+        borderRadius: "4px",
+        background: selected ? "rgba(59, 130, 246, 0.05)" : "var(--bg-main)",
+        cursor: disabled ? "default" : "pointer",
+        transition: "all 0.15s ease",
+      }}
+      onClick={disabled ? undefined : onSelect}
+    >
+      <input
+        type="radio"
+        checked={selected}
+        disabled={disabled}
+        onChange={disabled ? undefined : onSelect}
+        style={{ margin: 0, cursor: disabled ? "default" : "pointer" }}
+      />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <span style={{ fontSize: "13px", fontWeight: 600, color: "var(--text-primary)" }}>
+            {provider.name}
+          </span>
+          <StatusBadge status={provider.status} />
+        </div>
+        <div style={{ fontSize: "12px", color: "var(--text-secondary)", marginTop: "2px" }}>
+          {provider.description}
+        </div>
+      </div>
+      {onAction && actionLabel && (
+        <button
+          disabled={actionDisabled}
+          onClick={(e) => {
+            e.stopPropagation();
+            onAction();
+          }}
+          style={{
+            padding: "4px 12px",
+            fontSize: "12px",
+            background: "var(--btn-primary-bg)",
+            color: "var(--btn-primary-text)",
+            border: "none",
+            borderRadius: "4px",
+            cursor: actionDisabled ? "default" : "pointer",
+            opacity: actionDisabled ? 0.6 : 1,
+          }}
+        >
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
+}
+
+/** Modal for local provider setup with live log output */
+function SetupModal({
+  target,
+  onClose,
+  onComplete,
+}: {
+  target: "local-tts" | "local-stt";
+  onClose: () => void;
+  onComplete: () => void;
+}) {
+  const [log, setLog] = useState("");
+  const [running, setRunning] = useState(true);
+  const [exitCode, setExitCode] = useState<number | null>(null);
+  const preRef = useRef<HTMLPreElement>(null);
+  const startedRef = useRef(false);
+
+  // Auto-scroll to bottom when log updates
+  useEffect(() => {
+    if (preRef.current) {
+      preRef.current.scrollTop = preRef.current.scrollHeight;
+    }
+  }, [log]);
+
+  // Start the setup job and poll for updates
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+
+    let cancelled = false;
+
+    const run = async () => {
+      try {
+        const { jobId } = await post<{ jobId: string }>(
+          `/api/providers/setup/${target}`
+        );
+
+        // Small initial delay to let the process start
+        await new Promise((r) => setTimeout(r, 500));
+
+        const poll = async (): Promise<void> => {
+          if (cancelled) return;
+          try {
+            const status = await get<SetupJobStatus>(
+              `/api/providers/setup/status/${jobId}`
+            );
+            setLog(status.log);
+
+            if (status.running) {
+              await new Promise((r) => setTimeout(r, SETUP_POLL_INTERVAL_MS));
+              return poll();
+            }
+
+            setRunning(false);
+            setExitCode(status.exitCode);
+            if (status.exitCode === 0) onComplete();
+          } catch {
+            if (!cancelled) setRunning(false);
+          }
+        };
+
+        await poll();
+      } catch {
+        if (!cancelled) setRunning(false);
+      }
+    };
+
+    run();
+    return () => { cancelled = true; };
+  }, [target, onComplete]);
+
+  const title = target === "local-tts" ? "Setting up Local TTS" : "Setting up Local STT";
+
+  return (
+    <div className="modal-overlay visible" onClick={(e) => { if (e.target === e.currentTarget && !running) onClose(); }}>
+      <div className="modal" style={{ width: 640 }}>
+        <button className="modal-close" onClick={onClose} disabled={running}>&times;</button>
+        <h2>{title}</h2>
+        <p style={{ fontSize: 12, color: "var(--text-secondary)", marginBottom: 12 }}>
+          {running
+            ? "Installing dependencies. This may take a few minutes..."
+            : exitCode === 0
+              ? "Setup completed successfully."
+              : "Setup failed. Check the log below for details."}
+        </p>
+        <pre
+          ref={preRef}
+          style={{
+            background: "#1a1a2e",
+            color: "#e0e0e0",
+            padding: "12px 14px",
+            borderRadius: "4px",
+            fontSize: "11px",
+            lineHeight: "1.5",
+            maxHeight: "400px",
+            overflowY: "auto",
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+            margin: 0,
+            border: "1px solid var(--border-color)",
+          }}
+        >
+          {log || "Starting setup...\n"}
+        </pre>
+        <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 16 }}>
+          <button
+            onClick={onClose}
+            disabled={running}
+            style={{
+              padding: "6px 16px",
+              fontSize: "13px",
+              background: running ? "var(--bg-main)" : "var(--btn-primary-bg)",
+              color: running ? "var(--text-secondary)" : "var(--btn-primary-text)",
+              border: "1px solid var(--border-color)",
+              borderRadius: "4px",
+              cursor: running ? "default" : "pointer",
+            }}
+          >
+            {running ? "Running..." : "Close"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Shared styles for modal form fields */
+const fieldStyle: React.CSSProperties = { marginBottom: 14 };
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: 12,
+  fontWeight: 500,
+  color: "var(--text-primary)",
+  marginBottom: 4,
+};
+const modalInputStyle: React.CSSProperties = { width: "100%", boxSizing: "border-box" };
+const modalBtnRow: React.CSSProperties = { display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 8 };
+const cancelBtnStyle: React.CSSProperties = {
+  padding: "6px 16px",
+  fontSize: "13px",
+  background: "var(--bg-main)",
+  color: "var(--text-primary)",
+  border: "1px solid var(--border-color)",
+  borderRadius: "4px",
+  cursor: "pointer",
+};
+const applyBtnStyle: React.CSSProperties = {
+  padding: "6px 16px",
+  fontSize: "13px",
+  background: "var(--btn-primary-bg)",
+  color: "var(--btn-primary-text)",
+  border: "none",
+  borderRadius: "4px",
+  cursor: "pointer",
+};
+
+/** Modal for configuring ElevenLabs TTS settings */
+function ElevenLabsTtsModal({
+  apiKey,
+  voiceId,
+  modelId,
+  onSave,
+  onClose,
+}: {
+  apiKey: string;
+  voiceId: string;
+  modelId: string;
+  onSave: (values: { apiKey: string; voiceId: string; modelId: string }) => void;
+  onClose: () => void;
+}) {
+  const [localApiKey, setLocalApiKey] = useState(apiKey);
+  const [localVoiceId, setLocalVoiceId] = useState(voiceId);
+  const [localModelId, setLocalModelId] = useState(modelId);
+
+  const handleSave = () => {
+    onSave({ apiKey: localApiKey, voiceId: localVoiceId, modelId: localModelId });
+    onClose();
+  };
+
+  return (
+    <div className="modal-overlay visible" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="modal" style={{ width: 480 }}>
+        <button className="modal-close" onClick={onClose}>&times;</button>
+        <h2>ElevenLabs TTS</h2>
+        <p style={{ fontSize: 12, color: "var(--text-secondary)", marginBottom: 16 }}>
+          Configure API key, voice, and model for ElevenLabs text-to-speech.
+        </p>
+
+        <div style={fieldStyle}>
+          <label style={labelStyle}>API Key</label>
+          <input
+            type="password"
+            value={localApiKey}
+            onChange={(e) => setLocalApiKey(e.target.value)}
+            placeholder="Enter your ElevenLabs API key"
+            style={modalInputStyle}
+          />
+        </div>
+        <div style={fieldStyle}>
+          <label style={labelStyle}>Voice ID</label>
+          <input
+            type="text"
+            value={localVoiceId}
+            onChange={(e) => setLocalVoiceId(e.target.value)}
+            placeholder={DEFAULT_VOICE_ID}
+            style={modalInputStyle}
+          />
+        </div>
+        <div style={fieldStyle}>
+          <label style={labelStyle}>TTS Model ID</label>
+          <input
+            type="text"
+            value={localModelId}
+            onChange={(e) => setLocalModelId(e.target.value)}
+            placeholder={DEFAULT_MODEL_ID}
+            style={modalInputStyle}
+          />
+        </div>
+
+        <div style={modalBtnRow}>
+          <button onClick={onClose} style={cancelBtnStyle}>Cancel</button>
+          <button onClick={handleSave} style={applyBtnStyle}>Apply</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Modal for configuring ElevenLabs STT settings */
+function ElevenLabsSttModal({
+  apiKey,
+  sttModelId,
+  onSave,
+  onClose,
+}: {
+  apiKey: string;
+  sttModelId: string;
+  onSave: (values: { apiKey: string; sttModelId: string }) => void;
+  onClose: () => void;
+}) {
+  const [localApiKey, setLocalApiKey] = useState(apiKey);
+  const [localSttModelId, setLocalSttModelId] = useState(sttModelId);
+
+  const handleSave = () => {
+    onSave({ apiKey: localApiKey, sttModelId: localSttModelId });
+    onClose();
+  };
+
+  return (
+    <div className="modal-overlay visible" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="modal" style={{ width: 480 }}>
+        <button className="modal-close" onClick={onClose}>&times;</button>
+        <h2>ElevenLabs STT</h2>
+        <p style={{ fontSize: 12, color: "var(--text-secondary)", marginBottom: 16 }}>
+          Configure API key and model for ElevenLabs speech-to-text.
+        </p>
+
+        <div style={fieldStyle}>
+          <label style={labelStyle}>API Key</label>
+          <input
+            type="password"
+            value={localApiKey}
+            onChange={(e) => setLocalApiKey(e.target.value)}
+            placeholder="Enter your ElevenLabs API key"
+            style={modalInputStyle}
+          />
+        </div>
+        <div style={fieldStyle}>
+          <label style={labelStyle}>STT Model ID</label>
+          <input
+            type="text"
+            value={localSttModelId}
+            onChange={(e) => setLocalSttModelId(e.target.value)}
+            placeholder={DEFAULT_STT_MODEL_ID}
+            style={modalInputStyle}
+          />
+        </div>
+
+        <div style={modalBtnRow}>
+          <button onClick={onClose} style={cancelBtnStyle}>Cancel</button>
+          <button onClick={handleSave} style={applyBtnStyle}>Apply</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// RENDER
+// ============================================================================
+
+export function VoiceProvidersPanel() {
+  const [ttsProviders, setTtsProviders] = useState<ProviderInfo[]>([]);
+  const [sttProviders, setSttProviders] = useState<ProviderInfo[]>([]);
+  const [activeTts, setActiveTts] = useState("local");
+  const [activeStt, setActiveStt] = useState("local");
+  const [apiKey, setApiKey] = useState("");
+  const [voiceId, setVoiceId] = useState(DEFAULT_VOICE_ID);
+  const [modelId, setModelId] = useState(DEFAULT_MODEL_ID);
+  const [sttModelId, setSttModelId] = useState(DEFAULT_STT_MODEL_ID);
+  const [modal, setModal] = useState<ModalState>(null);
+
+  /** Persist a partial set of keys to .env */
+  const saveSettings = useCallback(async (values: Record<string, string>) => {
+    try {
+      await post("/api/settings", values);
+    } catch {
+      // Silently fail — the next voice session will use whatever is in .env
+    }
+  }, []);
+
+  // Load providers and settings on mount
+  useEffect(() => {
+    fetchTtsProviders()
+      .then((data) => {
+        setTtsProviders(data.providers);
+        setActiveTts(data.active);
+      })
+      .catch(() => {});
+
+    fetchSttProviders()
+      .then((data) => {
+        setSttProviders(data.providers);
+        setActiveStt(data.active);
+      })
+      .catch(() => {});
+
+    fetchSettings()
+      .then((data) => {
+        if (data.ELEVENLABS_API_KEY) setApiKey(data.ELEVENLABS_API_KEY);
+        if (data.ELEVENLABS_VOICE_ID) setVoiceId(data.ELEVENLABS_VOICE_ID);
+        if (data.ELEVENLABS_MODEL_ID) setModelId(data.ELEVENLABS_MODEL_ID);
+        if (data.ELEVENLABS_STT_MODEL_ID) setSttModelId(data.ELEVENLABS_STT_MODEL_ID);
+      })
+      .catch(() => {});
+  }, []);
+
+  /** Refresh provider lists after a setup completes */
+  const refreshProviders = useCallback(async () => {
+    try {
+      const [tts, stt] = await Promise.all([fetchTtsProviders(), fetchSttProviders()]);
+      setTtsProviders(tts.providers);
+      setSttProviders(stt.providers);
+    } catch {
+      // Ignore refresh errors
+    }
+  }, []);
+
+  /** Select a TTS provider and save immediately */
+  const selectTts = useCallback((type: string) => {
+    setActiveTts(type);
+    saveSettings({ TTS_PROVIDER: type });
+  }, [saveSettings]);
+
+  /** Select an STT provider and save immediately */
+  const selectStt = useCallback((type: string) => {
+    setActiveStt(type);
+    saveSettings({ STT_PROVIDER: type });
+  }, [saveSettings]);
+
+  /** Get action button config for a provider row */
+  const getAction = (providerType: string, status: ProviderStatus, section: "tts" | "stt") => {
+    if (providerType === "local" && !status.ready && status.reason === "not_installed") {
+      const target = section === "tts" ? "local-tts" : "local-stt";
+      return {
+        label: "Setup",
+        onAction: () => setModal({ kind: "setup" as const, target: target as "local-tts" | "local-stt" }),
+      };
+    }
+    if (providerType === "elevenlabs") {
+      const kind = section === "tts" ? "elevenlabs-tts" : "elevenlabs-stt";
+      return {
+        label: "Configure",
+        onAction: () => setModal({ kind: kind as "elevenlabs-tts" | "elevenlabs-stt" }),
+      };
+    }
+    return {};
+  };
+
+  return (
+    <>
+      <div
+        className="page-header"
+        style={{ borderBottom: "none", padding: 0, marginBottom: 24 }}
+      >
+        <div>
+          <h1>Voice Providers</h1>
+          <p style={{ fontSize: 13, color: "var(--text-secondary)", marginTop: 4 }}>
+            Select and configure TTS and STT providers. Changes take effect on the next voice
+            session.
+          </p>
+        </div>
+      </div>
+
+      {/* TTS Provider Section */}
+      <div className="settings-panel" style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, fontWeight: 600, color: "var(--text-primary)", marginBottom: 4 }}>
+          TTS Provider
+        </h2>
+        <p style={{ fontSize: 13, color: "var(--text-secondary)", marginBottom: 16 }}>
+          Choose which text-to-speech engine to use.
+        </p>
+        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+          {ttsProviders.map((p) => {
+            const action = getAction(p.type, p.status, "tts");
+            return (
+              <ProviderRow
+                key={p.type}
+                provider={p}
+                selected={activeTts === p.type}
+                onSelect={() => selectTts(p.type)}
+                onAction={action.onAction}
+                actionLabel={action.label}
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      {/* STT Provider Section */}
+      <div className="settings-panel" style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, fontWeight: 600, color: "var(--text-primary)", marginBottom: 4 }}>
+          STT Provider
+        </h2>
+        <p style={{ fontSize: 13, color: "var(--text-secondary)", marginBottom: 16 }}>
+          Choose which speech-to-text engine to use.
+        </p>
+        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+          {sttProviders.map((p) => {
+            const action = getAction(p.type, p.status, "stt");
+            return (
+              <ProviderRow
+                key={p.type}
+                provider={p}
+                selected={activeStt === p.type}
+                onSelect={() => selectStt(p.type)}
+                onAction={action.onAction}
+                actionLabel={action.label}
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Setup Modal (local provider installation) */}
+      {modal?.kind === "setup" && (
+        <SetupModal
+          target={modal.target}
+          onClose={() => setModal(null)}
+          onComplete={refreshProviders}
+        />
+      )}
+
+      {/* ElevenLabs TTS Configuration Modal */}
+      {modal?.kind === "elevenlabs-tts" && (
+        <ElevenLabsTtsModal
+          apiKey={apiKey}
+          voiceId={voiceId}
+          modelId={modelId}
+          onSave={(values) => {
+            setApiKey(values.apiKey);
+            setVoiceId(values.voiceId);
+            setModelId(values.modelId);
+            saveSettings({
+              ELEVENLABS_API_KEY: values.apiKey,
+              ELEVENLABS_VOICE_ID: values.voiceId,
+              ELEVENLABS_MODEL_ID: values.modelId,
+            });
+          }}
+          onClose={() => setModal(null)}
+        />
+      )}
+
+      {/* ElevenLabs STT Configuration Modal */}
+      {modal?.kind === "elevenlabs-stt" && (
+        <ElevenLabsSttModal
+          apiKey={apiKey}
+          sttModelId={sttModelId}
+          onSave={(values) => {
+            setApiKey(values.apiKey);
+            setSttModelId(values.sttModelId);
+            saveSettings({
+              ELEVENLABS_API_KEY: values.apiKey,
+              ELEVENLABS_STT_MODEL_ID: values.sttModelId,
+            });
+          }}
+          onClose={() => setModal(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/dashboard/src/pages/Settings.tsx
+++ b/dashboard/src/pages/Settings.tsx
@@ -2,15 +2,16 @@ import { useState, useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
 import { get } from "../api";
 import { SettingsPanel } from "../components/SettingsPanel";
+import { VoiceProvidersPanel } from "../components/VoiceProvidersPanel";
 import { McpServersPanel } from "../components/McpServersPanel";
 import { ClaudeMdEditor } from "../components/ClaudeMdEditor";
 import type { TunnelStatus, TwilioStatus, BrowserCallStatus } from "../pages/Home";
 
 export function Settings() {
     const [searchParams] = useSearchParams();
-    const initialTab = searchParams.get("tab") as "general" | "integrations" | "system" | null;
-    const [activeTab, setActiveTab] = useState<"general" | "integrations" | "system">(
-        initialTab === "integrations" || initialTab === "system" ? initialTab : "general"
+    const initialTab = searchParams.get("tab") as "general" | "voice" | "integrations" | "system" | null;
+    const [activeTab, setActiveTab] = useState<"general" | "voice" | "integrations" | "system">(
+        initialTab === "voice" || initialTab === "integrations" || initialTab === "system" ? initialTab : "general"
     );
     const [tunnelStatus, setTunnelStatus] = useState<TunnelStatus>({ running: false, url: null });
     const [twilioStatus, setTwilioStatus] = useState<TwilioStatus>({ running: false, tunnelUrl: null });
@@ -44,6 +45,7 @@ export function Settings() {
             {/* Tabs Row */}
             <div style={{ display: "flex", gap: "8px", padding: "24px 32px 16px", borderBottom: "1px solid var(--border-color)", flexShrink: 0 }}>
                 <button style={tabStyle("general")} onClick={() => setActiveTab("general")}>General</button>
+                <button style={tabStyle("voice")} onClick={() => setActiveTab("voice")}>Voice</button>
                 <button style={tabStyle("integrations")} onClick={() => setActiveTab("integrations")}>Integrations & MCP</button>
                 <button style={tabStyle("system")} onClick={() => setActiveTab("system")}>System Prompt</button>
             </div>
@@ -52,6 +54,9 @@ export function Settings() {
             <div style={{ flex: 1, overflowY: "auto", padding: "48px 64px" }}>
                 {activeTab === "general" && (
                     <SettingsPanel twilioRunning={twilioStatus.running} />
+                )}
+                {activeTab === "voice" && (
+                    <VoiceProvidersPanel />
                 )}
                 {activeTab === "integrations" && (
                     <McpServersPanel twilioRunning={twilioStatus.running} browserCallRunning={browserCallStatus.running} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "voicecc",
       "version": "1.0.11",
+      "hasInstallScript": true,
       "os": [
         "darwin"
       ],

--- a/scripts/setup-local-stt.js
+++ b/scripts/setup-local-stt.js
@@ -1,0 +1,159 @@
+/**
+ * On-demand setup for local STT (Whisper ONNX model download).
+ *
+ * Downloads the sherpa-onnx Whisper small.en model files to
+ * ~/.claude-voice-models/whisper-small/. The dashboard triggers this
+ * on demand when the user selects the local STT provider.
+ *
+ * Responsibilities:
+ * - Download the Whisper ONNX model archive from sherpa-onnx releases
+ * - Extract the required model files (encoder, decoder, tokens)
+ * - Report whether the local STT model is already installed
+ */
+
+import { execSync } from "child_process";
+import { existsSync, mkdirSync, renameSync, rmSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+/** Directory where Whisper model files are stored */
+const MODEL_DIR = join(homedir(), ".claude-voice-models", "whisper-small");
+
+/** URL for the sherpa-onnx Whisper small.en model archive */
+const MODEL_URL =
+  "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-whisper-small.en.tar.bz2";
+
+/** Archive filename after download */
+const ARCHIVE_NAME = "sherpa-onnx-whisper-small.en.tar.bz2";
+
+/** Directory name inside the extracted archive */
+const EXTRACTED_DIR_NAME = "sherpa-onnx-whisper-small.en";
+
+/** The 3 required model files for local Whisper STT */
+const REQUIRED_FILES = [
+  "small.en-encoder.int8.onnx",
+  "small.en-decoder.int8.onnx",
+  "small.en-tokens.txt",
+];
+
+// ============================================================================
+// MAIN HANDLERS
+// ============================================================================
+
+/**
+ * Download and install the Whisper ONNX model files for local STT.
+ *
+ * Steps: create model dir -> download archive -> extract -> move files -> cleanup.
+ *
+ * @throws {Error} If any step fails, with an actionable message
+ */
+export function setupLocalStt() {
+  if (isLocalSttInstalled()) {
+    console.log("Local STT model already installed, skipping.");
+    return;
+  }
+
+  // Ensure model directory exists
+  mkdirSync(MODEL_DIR, { recursive: true });
+
+  const archivePath = join(MODEL_DIR, ARCHIVE_NAME);
+  const extractedPath = join(MODEL_DIR, EXTRACTED_DIR_NAME);
+
+  try {
+    downloadArchive(archivePath);
+  } catch (err) {
+    throw new Error(`Failed to download Whisper model: ${err.message}`);
+  }
+
+  try {
+    extractArchive(archivePath);
+  } catch (err) {
+    throw new Error(`Failed to extract Whisper model archive: ${err.message}`);
+  }
+
+  try {
+    moveModelFiles(extractedPath);
+  } catch (err) {
+    throw new Error(`Failed to move model files: ${err.message}`);
+  }
+
+  try {
+    cleanup(archivePath, extractedPath);
+  } catch (err) {
+    // Cleanup failures are non-fatal, just log
+    console.warn(`Warning: cleanup failed: ${err.message}`);
+  }
+
+  console.log("Local STT model setup complete.");
+}
+
+/**
+ * Check whether the local STT model is already installed.
+ *
+ * @returns {boolean} True if all 3 required model files exist
+ */
+export function isLocalSttInstalled() {
+  return REQUIRED_FILES.every((file) => existsSync(join(MODEL_DIR, file)));
+}
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/**
+ * Download the model archive using curl.
+ *
+ * @param {string} archivePath - Destination path for the downloaded archive
+ */
+function downloadArchive(archivePath) {
+  console.log("Downloading Whisper ONNX model...");
+  execSync(`curl -L -o "${archivePath}" "${MODEL_URL}"`, { stdio: "inherit" });
+}
+
+/**
+ * Extract the tar.bz2 archive into the model directory.
+ *
+ * @param {string} archivePath - Path to the archive file
+ */
+function extractArchive(archivePath) {
+  console.log("Extracting model archive...");
+  execSync(`tar xjf "${archivePath}" -C "${MODEL_DIR}"`, { stdio: "inherit" });
+}
+
+/**
+ * Move the 3 required model files from the extracted directory to the model directory.
+ *
+ * @param {string} extractedPath - Path to the extracted archive directory
+ */
+function moveModelFiles(extractedPath) {
+  for (const file of REQUIRED_FILES) {
+    const src = join(extractedPath, file);
+    const dest = join(MODEL_DIR, file);
+
+    if (!existsSync(src)) {
+      throw new Error(`Expected model file not found in archive: ${file}`);
+    }
+
+    renameSync(src, dest);
+  }
+  console.log("Model files installed successfully.");
+}
+
+/**
+ * Remove the downloaded archive and extracted directory.
+ *
+ * @param {string} archivePath - Path to the archive file
+ * @param {string} extractedPath - Path to the extracted directory
+ */
+function cleanup(archivePath, extractedPath) {
+  if (existsSync(archivePath)) {
+    rmSync(archivePath);
+  }
+  if (existsSync(extractedPath)) {
+    rmSync(extractedPath, { recursive: true });
+  }
+}

--- a/scripts/setup-local-tts.js
+++ b/scripts/setup-local-tts.js
@@ -1,0 +1,206 @@
+/**
+ * On-demand setup for local TTS (Kokoro via mlx-audio).
+ *
+ * Extracted from postinstall.js so local model installation is no longer
+ * required at npm-install time. The dashboard triggers this on demand
+ * when the user selects the local TTS provider.
+ *
+ * Responsibilities:
+ * - Compile mic-vpio Swift binary (macOS VPIO echo cancellation)
+ * - Check for espeak-ng system dependency
+ * - Create Python virtual environment
+ * - Install mlx-audio and related Python packages
+ * - Download spaCy English model
+ * - Report whether local TTS is already installed
+ */
+
+import { execSync } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const VENV_DIR = join("sidecar", ".venv");
+const PIP = join(VENV_DIR, "bin", "pip");
+const PYTHON = join(VENV_DIR, "bin", "python3");
+const MIC_VPIO = join("sidecar", "mic-vpio");
+
+const PYTHON_PACKAGES = [
+  "mlx-audio",
+  "misaki",
+  "num2words",
+  "spacy",
+  "phonemizer",
+];
+
+// ============================================================================
+// MAIN HANDLERS
+// ============================================================================
+
+/**
+ * Run the full local TTS setup sequence.
+ *
+ * Steps: check platform -> compile mic-vpio -> check espeak-ng ->
+ * create Python venv -> install packages -> download spaCy model.
+ *
+ * @throws {Error} If any setup step fails, with an actionable message
+ */
+export function setupLocalTts() {
+  if (process.platform !== "darwin") {
+    throw new Error(
+      "Local TTS requires macOS with Apple Silicon. " +
+      "Set TTS_PROVIDER=elevenlabs in .env to use a cloud provider instead."
+    );
+  }
+
+  try {
+    compileMicVpio();
+  } catch (err) {
+    throw new Error(`Failed to compile mic-vpio: ${err.message}`);
+  }
+
+  try {
+    checkSystemDeps();
+  } catch (err) {
+    throw new Error(`Missing system dependencies: ${err.message}`);
+  }
+
+  try {
+    setupPythonVenv();
+  } catch (err) {
+    throw new Error(`Failed to create Python venv: ${err.message}`);
+  }
+
+  try {
+    installPythonPackages();
+  } catch (err) {
+    throw new Error(`Failed to install Python packages: ${err.message}`);
+  }
+
+  try {
+    downloadSpacyModel();
+  } catch (err) {
+    throw new Error(`Failed to download spaCy model: ${err.message}`);
+  }
+
+  console.log("Local TTS setup complete.");
+}
+
+/**
+ * Check whether local TTS is already installed.
+ *
+ * @returns {boolean} True if both the Python venv and mic-vpio binary exist
+ */
+export function isLocalTtsInstalled() {
+  return existsSync(PYTHON) && existsSync(MIC_VPIO);
+}
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/**
+ * Compile the mic-vpio Swift binary for macOS VPIO echo cancellation.
+ *
+ * @throws {Error} If swiftc is not found or compilation fails
+ */
+function compileMicVpio() {
+  if (existsSync(MIC_VPIO)) {
+    console.log("mic-vpio already compiled, skipping.");
+    return;
+  }
+
+  const source = join("sidecar", "mic-vpio.swift");
+
+  if (!commandExists("swiftc")) {
+    throw new Error(
+      "Swift compiler (swiftc) not found. " +
+      "Install Xcode Command Line Tools: xcode-select --install"
+    );
+  }
+
+  console.log("Compiling mic-vpio (VPIO echo cancellation)...");
+  run(`swiftc -O -o ${MIC_VPIO} ${source} -framework AudioToolbox -framework CoreAudio`);
+  console.log("mic-vpio compiled successfully.");
+}
+
+/**
+ * Check that required system dependencies (espeak-ng) are installed.
+ *
+ * @throws {Error} If espeak-ng is not found
+ */
+function checkSystemDeps() {
+  if (!commandExists("espeak-ng")) {
+    throw new Error(
+      "espeak-ng is not installed. Install with: brew install espeak-ng"
+    );
+  }
+  console.log("System dependencies OK (espeak-ng).");
+}
+
+/**
+ * Create the Python virtual environment if it does not exist.
+ *
+ * @throws {Error} If python3 is not found or venv creation fails
+ */
+function setupPythonVenv() {
+  if (existsSync(PIP)) {
+    console.log(`Python venv already exists at ${VENV_DIR}.`);
+    return;
+  }
+
+  if (!commandExists("python3")) {
+    throw new Error(
+      "python3 not found. Install Python 3 via: brew install python3"
+    );
+  }
+
+  console.log(`Creating Python venv at ${VENV_DIR}...`);
+  run(`python3 -m venv ${VENV_DIR}`);
+}
+
+/**
+ * Install required Python packages into the virtual environment.
+ *
+ * @throws {Error} If pip install fails
+ */
+function installPythonPackages() {
+  console.log("Installing Python TTS packages...");
+  run(`${PIP} install ${PYTHON_PACKAGES.join(" ")}`);
+}
+
+/**
+ * Download the spaCy English language model.
+ *
+ * @throws {Error} If spaCy download fails
+ */
+function downloadSpacyModel() {
+  console.log("Downloading spaCy English model...");
+  run(`${PYTHON} -m spacy download en_core_web_sm`);
+}
+
+/**
+ * Check whether a command exists on the system PATH.
+ *
+ * @param {string} cmd - Command name to look up
+ * @returns {boolean} True if the command is found
+ */
+function commandExists(cmd) {
+  try {
+    execSync(`which ${cmd}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Run a shell command synchronously with inherited stdio.
+ *
+ * @param {string} cmd - Shell command to execute
+ */
+function run(cmd) {
+  execSync(cmd, { stdio: "inherit" });
+}

--- a/sidecar/browser-server.ts
+++ b/sidecar/browser-server.ts
@@ -31,6 +31,7 @@ import type { IncomingMessage, ServerResponse } from "http";
 import type { Duplex } from "stream";
 import type { WebSocket } from "ws";
 import type { VoiceSession } from "./voice-session.js";
+import type { TtsProviderConfig, SttProviderConfig, TtsProviderType, SttProviderType } from "./types.js";
 
 // ============================================================================
 // CONSTANTS
@@ -45,13 +46,33 @@ const BROWSER_INTERRUPTION_THRESHOLD_MS = 1500;
 /** Ping interval to keep WebSocket connections alive through tunnel (ms) */
 const PING_INTERVAL_MS = 30_000;
 
+/** Read provider selection and ElevenLabs config from environment */
+const TTS_PROVIDER = (process.env.TTS_PROVIDER ?? "local") as TtsProviderType;
+const STT_PROVIDER = (process.env.STT_PROVIDER ?? "local") as SttProviderType;
+const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY ?? "";
+const ELEVENLABS_VOICE_ID = process.env.ELEVENLABS_VOICE_ID ?? "JBFqnCBsd6RMkjVDRZzb";
+const ELEVENLABS_MODEL_ID = process.env.ELEVENLABS_MODEL_ID ?? "eleven_turbo_v2_5";
+const ELEVENLABS_STT_MODEL_ID = process.env.ELEVENLABS_STT_MODEL_ID ?? "scribe_v1";
+
+/** TTS provider configuration built from env vars */
+const ttsProvider: TtsProviderConfig = {
+  provider: TTS_PROVIDER,
+  local: { model: "prince-canuma/Kokoro-82M", voice: "af_heart" },
+  elevenlabs: { apiKey: ELEVENLABS_API_KEY, voiceId: ELEVENLABS_VOICE_ID, modelId: ELEVENLABS_MODEL_ID },
+};
+
+/** STT provider configuration built from env vars */
+const sttProvider: SttProviderConfig = {
+  provider: STT_PROVIDER,
+  local: { modelPath: join(homedir(), ".claude-voice-models", "whisper-small") },
+  elevenlabs: { apiKey: ELEVENLABS_API_KEY, modelId: ELEVENLABS_STT_MODEL_ID },
+};
+
 /** Default voice session config for browser calls */
 const DEFAULT_CONFIG = {
   stopPhrase: "stop listening",
-  sttModelPath: join(homedir(), ".claude-voice-models", "whisper-small"),
-  ttsModel: "prince-canuma/Kokoro-82M",
-  ttsVoice: "af_heart",
-  modelCacheDir: join(homedir(), ".claude-voice-models"),
+  ttsProvider,
+  sttProvider,
   interruptionThresholdMs: BROWSER_INTERRUPTION_THRESHOLD_MS,
   endpointing: {
     silenceThresholdMs: 700,

--- a/sidecar/index.ts
+++ b/sidecar/index.ts
@@ -19,6 +19,8 @@ import { join } from "path";
 import { createLocalAudioAdapter } from "./local-audio.js";
 import { createVoiceSession } from "./voice-session.js";
 
+import type { TtsProviderConfig, SttProviderConfig, TtsProviderType, SttProviderType } from "./types.js";
+
 // ============================================================================
 // CONSTANTS
 // ============================================================================
@@ -29,13 +31,33 @@ const MIC_SAMPLE_RATE = 16000;
 /** TTS output sample rate in Hz -- must match tts-server.py output format */
 const TTS_SAMPLE_RATE = 24000;
 
+/** Read provider selection and ElevenLabs config from environment */
+const TTS_PROVIDER = (process.env.TTS_PROVIDER ?? "local") as TtsProviderType;
+const STT_PROVIDER = (process.env.STT_PROVIDER ?? "local") as SttProviderType;
+const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY ?? "";
+const ELEVENLABS_VOICE_ID = process.env.ELEVENLABS_VOICE_ID ?? "JBFqnCBsd6RMkjVDRZzb";
+const ELEVENLABS_MODEL_ID = process.env.ELEVENLABS_MODEL_ID ?? "eleven_turbo_v2_5";
+const ELEVENLABS_STT_MODEL_ID = process.env.ELEVENLABS_STT_MODEL_ID ?? "scribe_v1";
+
+/** TTS provider configuration built from env vars */
+const ttsProvider: TtsProviderConfig = {
+  provider: TTS_PROVIDER,
+  local: { model: "prince-canuma/Kokoro-82M", voice: "af_heart" },
+  elevenlabs: { apiKey: ELEVENLABS_API_KEY, voiceId: ELEVENLABS_VOICE_ID, modelId: ELEVENLABS_MODEL_ID },
+};
+
+/** STT provider configuration built from env vars */
+const sttProvider: SttProviderConfig = {
+  provider: STT_PROVIDER,
+  local: { modelPath: join(homedir(), ".claude-voice-models", "whisper-small") },
+  elevenlabs: { apiKey: ELEVENLABS_API_KEY, modelId: ELEVENLABS_STT_MODEL_ID },
+};
+
 /** Default configuration for the voice session */
 const DEFAULT_CONFIG = {
   stopPhrase: "stop listening",
-  sttModelPath: join(homedir(), ".claude-voice-models", "whisper-small"),
-  ttsModel: "prince-canuma/Kokoro-82M",
-  ttsVoice: "af_heart",
-  modelCacheDir: join(homedir(), ".claude-voice-models"),
+  ttsProvider,
+  sttProvider,
   interruptionThresholdMs: 1500,
   endpointing: {
     silenceThresholdMs: 700,

--- a/sidecar/stt-elevenlabs.ts
+++ b/sidecar/stt-elevenlabs.ts
@@ -1,0 +1,211 @@
+/**
+ * ElevenLabs STT provider via batch transcription API (Scribe v2).
+ *
+ * Accumulates audio samples locally during speech, then sends the full buffer
+ * to the ElevenLabs speech-to-text API on transcribe(). Audio is encoded as a
+ * WAV file (16kHz mono 16-bit PCM) before upload.
+ *
+ * Responsibilities:
+ * - Accumulate Float32Array audio chunks during speech
+ * - Encode accumulated audio as a WAV file for upload
+ * - POST the WAV to the ElevenLabs batch STT API via multipart/form-data
+ * - Parse the JSON response and return a TranscriptionResult
+ * - Clear the buffer after transcription or on demand
+ */
+
+import type { SttProcessor } from "./stt.js";
+import type { TranscriptionResult } from "./types.js";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+/** ElevenLabs STT API endpoint */
+const ELEVENLABS_STT_URL = "https://api.elevenlabs.io/v1/speech-to-text";
+
+/** Sample rate for the WAV file (must match input audio from microphone) */
+const WAV_SAMPLE_RATE = 16000;
+
+/** Number of audio channels */
+const WAV_CHANNELS = 1;
+
+/** Bits per sample in the WAV file */
+const WAV_BIT_DEPTH = 16;
+
+/** Size of the WAV file header in bytes */
+const WAV_HEADER_SIZE = 44;
+
+// ============================================================================
+// INTERFACES
+// ============================================================================
+
+/**
+ * Configuration for the ElevenLabs STT provider.
+ */
+export interface ElevenlabsSttConfig {
+  /** ElevenLabs API key for authentication */
+  apiKey: string;
+  /** ElevenLabs STT model ID (e.g. "scribe_v1") */
+  modelId: string;
+}
+
+// ============================================================================
+// MAIN HANDLERS
+// ============================================================================
+
+/**
+ * Create an SttProcessor that uses the ElevenLabs batch transcription API.
+ *
+ * Audio is accumulated locally via accumulate(), then the full buffer is
+ * encoded as WAV and sent to ElevenLabs on transcribe(). This fits the
+ * existing SttProcessor interface without changes.
+ *
+ * @param config - ElevenLabs STT configuration (API key and model ID)
+ * @returns An SttProcessor instance ready for transcription
+ */
+export async function createElevenlabsStt(config: ElevenlabsSttConfig): Promise<SttProcessor> {
+  const { apiKey, modelId } = config;
+
+  let audioChunks: Float32Array[] = [];
+
+  /**
+   * Append audio samples to the internal buffer.
+   * @param samples - Float32Array of audio samples (16kHz, normalized -1.0 to 1.0)
+   */
+  function accumulate(samples: Float32Array): void {
+    audioChunks.push(samples);
+  }
+
+  /**
+   * Transcribe the accumulated audio buffer by sending it to the ElevenLabs API.
+   * Encodes the audio as WAV, uploads via multipart/form-data, and parses the result.
+   *
+   * @returns Transcription result with text, isFinal flag, and timestamp
+   * @throws Error on empty buffer, non-2xx response, or network failure
+   */
+  async function transcribe(): Promise<TranscriptionResult> {
+    const combinedSamples = concatenateChunks(audioChunks);
+    audioChunks = [];
+
+    if (combinedSamples.length === 0) {
+      return { text: "", isFinal: true, timestamp: Date.now() };
+    }
+
+    // Encode audio as WAV and upload to ElevenLabs
+    const wavBuffer = encodeWav(combinedSamples);
+    const wavBlob = new Blob([wavBuffer], { type: "audio/wav" });
+
+    const formData = new FormData();
+    formData.append("file", wavBlob, "audio.wav");
+    formData.append("model_id", modelId);
+
+    const response = await fetch(ELEVENLABS_STT_URL, {
+      method: "POST",
+      headers: {
+        "xi-api-key": apiKey,
+      },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "unknown error");
+      throw new Error(`ElevenLabs STT API error ${response.status}: ${errorText}`);
+    }
+
+    const result = await response.json() as { text: string };
+
+    return { text: result.text.trim(), isFinal: true, timestamp: Date.now() };
+  }
+
+  /**
+   * Clear the accumulated audio buffer without transcribing.
+   */
+  function clearBuffer(): void {
+    audioChunks = [];
+  }
+
+  /**
+   * Free resources. Clears the buffer (no external resources to release).
+   */
+  function destroy(): void {
+    audioChunks = [];
+  }
+
+  return {
+    accumulate,
+    transcribe,
+    clearBuffer,
+    destroy,
+  };
+}
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/**
+ * Encode Float32Array audio samples as a WAV file buffer.
+ * Writes a 44-byte WAV header followed by 16-bit signed PCM data.
+ *
+ * @param samples - Float32Array of audio samples (normalized -1.0 to 1.0)
+ * @returns Buffer containing a valid WAV file
+ */
+function encodeWav(samples: Float32Array): Buffer {
+  const bytesPerSample = WAV_BIT_DEPTH / 8;
+  const dataSize = samples.length * bytesPerSample;
+  const fileSize = WAV_HEADER_SIZE + dataSize;
+
+  const buffer = Buffer.alloc(fileSize);
+  let offset = 0;
+
+  // RIFF header
+  buffer.write("RIFF", offset); offset += 4;
+  buffer.writeUInt32LE(fileSize - 8, offset); offset += 4;
+  buffer.write("WAVE", offset); offset += 4;
+
+  // fmt sub-chunk
+  buffer.write("fmt ", offset); offset += 4;
+  buffer.writeUInt32LE(16, offset); offset += 4;             // Sub-chunk size (16 for PCM)
+  buffer.writeUInt16LE(1, offset); offset += 2;              // Audio format (1 = PCM)
+  buffer.writeUInt16LE(WAV_CHANNELS, offset); offset += 2;   // Number of channels
+  buffer.writeUInt32LE(WAV_SAMPLE_RATE, offset); offset += 4; // Sample rate
+  buffer.writeUInt32LE(WAV_SAMPLE_RATE * WAV_CHANNELS * bytesPerSample, offset); offset += 4; // Byte rate
+  buffer.writeUInt16LE(WAV_CHANNELS * bytesPerSample, offset); offset += 2; // Block align
+  buffer.writeUInt16LE(WAV_BIT_DEPTH, offset); offset += 2;  // Bits per sample
+
+  // data sub-chunk
+  buffer.write("data", offset); offset += 4;
+  buffer.writeUInt32LE(dataSize, offset); offset += 4;
+
+  // Convert float samples to 16-bit signed PCM
+  for (let i = 0; i < samples.length; i++) {
+    const clamped = Math.max(-1, Math.min(1, samples[i]));
+    const int16 = clamped < 0 ? clamped * 0x8000 : clamped * 0x7FFF;
+    buffer.writeInt16LE(Math.round(int16), offset);
+    offset += 2;
+  }
+
+  return buffer;
+}
+
+/**
+ * Concatenate an array of Float32Array chunks into a single Float32Array.
+ *
+ * @param chunks - Array of Float32Array audio chunks
+ * @returns Single concatenated Float32Array
+ */
+function concatenateChunks(chunks: Float32Array[]): Float32Array {
+  if (chunks.length === 0) return new Float32Array(0);
+  if (chunks.length === 1) return chunks[0];
+
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const result = new Float32Array(totalLength);
+
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return result;
+}

--- a/sidecar/stt-provider.ts
+++ b/sidecar/stt-provider.ts
@@ -1,0 +1,155 @@
+/**
+ * STT provider factory and readiness checks.
+ *
+ * Routes STT creation to the correct provider implementation based on config.
+ * Checks provider readiness (model files, API keys) for dashboard status.
+ *
+ * Responsibilities:
+ * - Create an SttProcessor for the configured provider (local or ElevenLabs)
+ * - Check provider readiness (model files exist, API keys set)
+ * - Provide static metadata about available STT providers
+ */
+
+import { existsSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+import { createLocalStt } from "./stt.js";
+import { createElevenlabsStt } from "./stt-elevenlabs.js";
+import { readEnv } from "../services/env.js";
+
+import type { SttProcessor } from "./stt.js";
+import type { SttProviderType, SttProviderConfig, ProviderStatus } from "./types.js";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+/** Standard path where local Whisper model files are stored */
+const LOCAL_STT_MODEL_DIR = join(homedir(), ".claude-voice-models", "whisper-small");
+
+/** Required model files for local Whisper STT */
+const REQUIRED_MODEL_FILES = [
+  "small.en-encoder.int8.onnx",
+  "small.en-decoder.int8.onnx",
+  "small.en-tokens.txt",
+];
+
+// ============================================================================
+// INTERFACES
+// ============================================================================
+
+/**
+ * Metadata about an STT provider for display in the dashboard.
+ */
+export interface SttProviderInfo {
+  /** Provider type identifier */
+  type: SttProviderType;
+  /** Human-readable provider name */
+  name: string;
+  /** Short description of the provider */
+  description: string;
+  /** Platform required for this provider (undefined = any platform) */
+  requiresPlatform?: "darwin";
+  /** Environment variable name for the API key (undefined = no key needed) */
+  requiresApiKey?: string;
+}
+
+/**
+ * Options for creating an STT processor via the provider factory.
+ */
+export interface CreateSttOptions {
+  /** Provider configuration (which provider + per-provider settings) */
+  providerConfig: SttProviderConfig;
+}
+
+// ============================================================================
+// MAIN HANDLERS
+// ============================================================================
+
+/**
+ * Create an SttProcessor for the configured provider.
+ * Routes to the local Whisper provider or ElevenLabs cloud provider.
+ *
+ * @param options - Provider config with per-provider settings
+ * @returns An SttProcessor instance ready for transcription
+ * @throws Error if the provider is not implemented
+ */
+export async function createSttForProvider(options: CreateSttOptions): Promise<SttProcessor> {
+  const { providerConfig } = options;
+
+  switch (providerConfig.provider) {
+    case "local":
+      return createLocalStt(providerConfig.local.modelPath);
+
+    case "elevenlabs":
+      return createElevenlabsStt({
+        apiKey: providerConfig.elevenlabs.apiKey,
+        modelId: providerConfig.elevenlabs.modelId,
+      });
+
+    default:
+      throw new Error(`Unknown STT provider: ${providerConfig.provider}`);
+  }
+}
+
+/**
+ * Check whether an STT provider is ready to use.
+ *
+ * Local: checks that the 3 required Whisper model files exist at the standard path.
+ * ElevenLabs: checks ELEVENLABS_API_KEY is set in .env.
+ *
+ * @param providerType - The provider to check
+ * @returns Readiness status with reason if not ready
+ */
+export async function getSttProviderStatus(providerType: SttProviderType): Promise<ProviderStatus> {
+  switch (providerType) {
+    case "local": {
+      const missingFiles = REQUIRED_MODEL_FILES.filter(
+        (file) => !existsSync(join(LOCAL_STT_MODEL_DIR, file))
+      );
+
+      if (missingFiles.length > 0) {
+        return {
+          ready: false,
+          reason: "not_installed",
+          detail: `Missing model files in ${LOCAL_STT_MODEL_DIR}: ${missingFiles.join(", ")}`,
+        };
+      }
+      return { ready: true };
+    }
+
+    case "elevenlabs": {
+      const env = await readEnv();
+      if (!env.ELEVENLABS_API_KEY) {
+        return { ready: false, reason: "missing_api_key", detail: "ELEVENLABS_API_KEY is not set in .env" };
+      }
+      return { ready: true };
+    }
+
+    default:
+      throw new Error(`Unknown STT provider: ${providerType}`);
+  }
+}
+
+/**
+ * Get the list of all known STT providers with metadata.
+ *
+ * @returns Static array of STT provider info
+ */
+export function getAvailableSttProviders(): SttProviderInfo[] {
+  return [
+    {
+      type: "local",
+      name: "Local Whisper",
+      description: "On-device STT via sherpa-onnx Whisper ONNX model (offline batch mode)",
+      requiresPlatform: "darwin",
+    },
+    {
+      type: "elevenlabs",
+      name: "ElevenLabs Scribe",
+      description: "Cloud STT via ElevenLabs batch transcription API",
+      requiresApiKey: "ELEVENLABS_API_KEY",
+    },
+  ];
+}

--- a/sidecar/stt.ts
+++ b/sidecar/stt.ts
@@ -1,5 +1,5 @@
 /**
- * Local speech-to-text via sherpa-onnx with Whisper ONNX model (offline/batch).
+ * Local Whisper STT provider via sherpa-onnx with Whisper ONNX model (offline/batch).
  *
  * Whisper models in sherpa-onnx are offline-only (not streaming). Audio is
  * accumulated during speech (SPEECH_START to SPEECH_END), then batch-transcribed
@@ -19,8 +19,8 @@ import type { TranscriptionResult } from "./types.js";
 // INTERFACES
 // ============================================================================
 
-/** Internal interface for the STT processor returned by createStt. */
-interface SttProcessor {
+/** Internal interface for the STT processor returned by createLocalStt. */
+export interface SttProcessor {
   /**
    * Appends audio samples to the internal buffer.
    * Call continuously during speech (between SPEECH_START and SPEECH_END).
@@ -76,7 +76,7 @@ const REQUIRED_SUFFIXES = ["-encoder.int8.onnx", "-decoder.int8.onnx", "-tokens.
  * @returns Promise resolving to an SttProcessor instance
  * @throws Error if any required model files are missing
  */
-async function createStt(modelPath: string): Promise<SttProcessor> {
+async function createLocalStt(modelPath: string): Promise<SttProcessor> {
   validateModelFiles(modelPath);
 
   // Dynamic import to avoid ONNX runtime conflict with kokoro-js.
@@ -195,5 +195,4 @@ function concatenateChunks(chunks: Float32Array[]): Float32Array {
   return result;
 }
 
-export { createStt };
-export type { SttProcessor };
+export { createLocalStt };

--- a/sidecar/tts-elevenlabs.ts
+++ b/sidecar/tts-elevenlabs.ts
@@ -1,0 +1,320 @@
+/**
+ * ElevenLabs TTS provider via streaming HTTP API.
+ *
+ * Calls the ElevenLabs text-to-speech streaming endpoint to generate audio,
+ * then writes raw PCM chunks to the speaker stream for playback. No subprocess
+ * is needed -- audio is fetched over HTTP and piped directly into the pipeline.
+ *
+ * Responsibilities:
+ * - POST text to the ElevenLabs TTS streaming API and receive chunked PCM audio
+ * - Buffer streaming text deltas into sentences via shared bufferSentences utility
+ * - Write PCM audio to the speaker stream with backpressure handling
+ * - Track playback timing and wait for audio to finish before resolving
+ * - Support interruption by cancelling in-flight requests and clearing playback
+ */
+
+import { bufferSentences, writePcm } from "./tts.js";
+
+import type { Writable } from "stream";
+import type { TtsPlayer } from "./tts.js";
+import type { TextChunk } from "./types.js";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+/** ElevenLabs TTS streaming API base URL */
+const ELEVENLABS_TTS_BASE_URL = "https://api.elevenlabs.io/v1/text-to-speech";
+
+/** PCM output sample rate in Hz (must match speaker pipeline) */
+const TTS_SAMPLE_RATE = 24000;
+
+/** Speaker audio bit depth */
+const SPEAKER_BIT_DEPTH = 16;
+
+/** Speaker channel count */
+const SPEAKER_CHANNELS = 1;
+
+/** Bytes per second of PCM audio at 24kHz 16-bit mono */
+const BYTES_PER_SECOND = TTS_SAMPLE_RATE * (SPEAKER_BIT_DEPTH / 8) * SPEAKER_CHANNELS;
+
+/** Interval (ms) for checking the interrupt flag during playback wait */
+const INTERRUPT_CHECK_INTERVAL_MS = 50;
+
+// ============================================================================
+// INTERFACES
+// ============================================================================
+
+/**
+ * Configuration for the ElevenLabs TTS provider.
+ */
+export interface ElevenlabsTtsConfig {
+  /** ElevenLabs API key for authentication */
+  apiKey: string;
+  /** ElevenLabs voice ID to use for generation */
+  voiceId: string;
+  /** ElevenLabs model ID (e.g. "eleven_monolingual_v1") */
+  modelId: string;
+  /** Writable stream for PCM audio output */
+  speakerInput: Writable;
+  /** Callback to clear the playback buffer on interruption */
+  interruptPlayback: () => void;
+  /** Callback to resume playback after an interrupt */
+  resumePlayback: () => void;
+}
+
+// ============================================================================
+// MAIN HANDLERS
+// ============================================================================
+
+/**
+ * Create a TtsPlayer that uses the ElevenLabs streaming TTS API.
+ *
+ * Sends text to the ElevenLabs API and receives raw PCM audio at 24kHz 16-bit
+ * mono, which is written directly to the speaker stream. No format conversion
+ * is needed since the output matches the speaker pipeline exactly.
+ *
+ * @param config - ElevenLabs TTS configuration (API key, voice, model, speaker stream)
+ * @returns A TtsPlayer instance ready for playback
+ */
+export async function createElevenlabsTts(config: ElevenlabsTtsConfig): Promise<TtsPlayer> {
+  const { apiKey, voiceId, modelId, speakerInput, interruptPlayback, resumePlayback } = config;
+
+  let destroyed = false;
+  let speaking = false;
+  let interruptFlag = false;
+  let wasInterrupted = false;
+
+  /**
+   * POST text to the ElevenLabs TTS streaming endpoint and stream PCM chunks
+   * to the speaker. Returns the total number of PCM bytes written.
+   *
+   * @param text - The text to synthesize
+   * @returns Total PCM bytes written to the speaker stream
+   */
+  async function streamTtsToSpeaker(text: string): Promise<number> {
+    const url = `${ELEVENLABS_TTS_BASE_URL}/${voiceId}/stream?output_format=pcm_24000`;
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "xi-api-key": apiKey,
+      },
+      body: JSON.stringify({ text, model_id: modelId }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "unknown error");
+      throw new Error(`ElevenLabs TTS API error ${response.status}: ${errorText}`);
+    }
+
+    let totalBytes = 0;
+
+    for await (const chunk of readResponseChunks(response)) {
+      if (interruptFlag) break;
+
+      const pcmBuffer = Buffer.from(chunk);
+      totalBytes += pcmBuffer.length;
+      await writePcm(speakerInput, pcmBuffer);
+    }
+
+    return totalBytes;
+  }
+
+  /**
+   * Wait for the estimated remaining playback time, allowing interruption to cancel.
+   *
+   * @param remainingMs - Milliseconds to wait for playback to finish
+   */
+  function waitForPlayback(remainingMs: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, remainingMs);
+
+      // Poll the interrupt flag to allow early cancellation
+      const check = setInterval(() => {
+        if (interruptFlag) {
+          clearTimeout(timer);
+          clearInterval(check);
+          resolve();
+        }
+      }, INTERRUPT_CHECK_INTERVAL_MS);
+
+      // Clean up interval when timer fires naturally
+      setTimeout(() => clearInterval(check), remainingMs + 100);
+    });
+  }
+
+  /**
+   * Generate audio for a single text string via ElevenLabs API and play it.
+   * @param text - The text to speak
+   */
+  async function speak(text: string): Promise<void> {
+    if (destroyed) throw new Error("TtsPlayer has been destroyed");
+
+    interruptFlag = false;
+    speaking = true;
+
+    if (wasInterrupted) {
+      resumePlayback();
+      wasInterrupted = false;
+    }
+
+    try {
+      await streamTtsToSpeaker(text);
+    } finally {
+      speaking = false;
+    }
+  }
+
+  /**
+   * Stream text chunks into TTS for pipelined playback.
+   * Buffers text deltas into sentences, generates audio per sentence via
+   * the ElevenLabs API, and writes PCM to the speaker stream.
+   * @param texts - Async iterable of text chunks from the narrator
+   */
+  async function speakStream(texts: AsyncIterable<TextChunk>): Promise<void> {
+    if (destroyed) throw new Error("TtsPlayer has been destroyed");
+
+    const t0 = Date.now();
+    let firstTextLogged = false;
+    let chunkIndex = 0;
+    let playbackFinishAt = 0;
+
+    interruptFlag = false;
+    speaking = true;
+
+    if (wasInterrupted) {
+      resumePlayback();
+      wasInterrupted = false;
+    }
+
+    try {
+      for await (const sentence of bufferSentences(texts)) {
+        if (interruptFlag) break;
+
+        if (!firstTextLogged) {
+          console.log(`[tts-elevenlabs] first sentence at +${Date.now() - t0}ms: "${sentence.slice(0, 50)}${sentence.length > 50 ? "..." : ""}"`);
+          firstTextLogged = true;
+        }
+
+        const sentAt = Date.now();
+
+        // Fetch streamed PCM from ElevenLabs
+        const url = `${ELEVENLABS_TTS_BASE_URL}/${voiceId}/stream?output_format=pcm_24000`;
+        const response = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "xi-api-key": apiKey,
+          },
+          body: JSON.stringify({ text: sentence, model_id: modelId }),
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => "unknown error");
+          throw new Error(`ElevenLabs TTS API error ${response.status}: ${errorText}`);
+        }
+
+        if (interruptFlag) break;
+
+        // Read chunked PCM from the response body
+        for await (const chunk of readResponseChunks(response)) {
+          if (interruptFlag) break;
+
+          const pcmBuffer = Buffer.from(chunk);
+          const now = Date.now() - t0;
+          const audioDurationMs = (pcmBuffer.length / BYTES_PER_SECOND) * 1000;
+          const genMs = Date.now() - sentAt;
+
+          console.log(
+            `[tts-elevenlabs] chunk ${chunkIndex} at +${now}ms (${(audioDurationMs / 1000).toFixed(1)}s audio, generated in ${genMs}ms)`
+          );
+          chunkIndex++;
+
+          await writePcm(speakerInput, pcmBuffer);
+
+          // Track estimated playback end. If the speaker buffer drained during a
+          // gap (e.g. tool call), new audio starts from now, not after previous audio.
+          playbackFinishAt = Math.max(playbackFinishAt, Date.now()) + audioDurationMs;
+        }
+
+        if (interruptFlag) break;
+      }
+
+      // Wait for buffered audio to finish playing through the speakers
+      if (!interruptFlag && playbackFinishAt > 0) {
+        const remainingMs = playbackFinishAt - Date.now();
+        if (remainingMs > 0) {
+          console.log(`[tts-elevenlabs] waiting ${(remainingMs / 1000).toFixed(1)}s for playback to finish`);
+          await waitForPlayback(remainingMs);
+        }
+      }
+    } finally {
+      speaking = false;
+    }
+  }
+
+  /**
+   * Interrupt current playback and cancel in-flight generation.
+   * Clears the playback buffer and sets the interrupt flag.
+   */
+  function interrupt(): void {
+    if (destroyed) return;
+    interruptFlag = true;
+    wasInterrupted = true;
+    interruptPlayback();
+  }
+
+  /**
+   * Check whether TTS is currently active.
+   * @returns true if a speak/speakStream call is in progress
+   */
+  function checkIsSpeaking(): boolean {
+    return speaking;
+  }
+
+  /**
+   * Free all resources and prevent further usage.
+   */
+  function destroyPlayer(): void {
+    if (destroyed) return;
+    destroyed = true;
+    interrupt();
+  }
+
+  return {
+    speak,
+    speakStream,
+    interrupt,
+    isSpeaking: checkIsSpeaking,
+    destroy: destroyPlayer,
+  };
+}
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/**
+ * Read chunks from a fetch Response body as an async iterable.
+ * The response body is a ReadableStream of Uint8Array chunks.
+ *
+ * @param response - The fetch Response to read from
+ * @yields Uint8Array chunks of raw PCM audio data
+ */
+async function* readResponseChunks(response: Response): AsyncGenerator<Uint8Array> {
+  const body = response.body;
+  if (!body) throw new Error("ElevenLabs TTS response has no body");
+
+  const reader = body.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) yield value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/sidecar/tts-provider.ts
+++ b/sidecar/tts-provider.ts
@@ -1,0 +1,168 @@
+/**
+ * TTS provider factory and readiness checks.
+ *
+ * Routes TTS creation to the correct provider implementation based on config.
+ * Checks provider readiness (platform, binaries, API keys) for dashboard status.
+ *
+ * Responsibilities:
+ * - Create a TtsPlayer for the configured provider (local or ElevenLabs)
+ * - Check provider readiness (installed binaries, API keys, platform)
+ * - Provide static metadata about available TTS providers
+ */
+
+import { existsSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+import { createLocalTts } from "./tts.js";
+import { createElevenlabsTts } from "./tts-elevenlabs.js";
+import { readEnv } from "../services/env.js";
+
+import type { Writable } from "stream";
+import type { TtsPlayer } from "./tts.js";
+import type { TtsProviderType, TtsProviderConfig, ProviderStatus } from "./types.js";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Path to the Python venv binary (required for local TTS) */
+const PYTHON_VENV_PATH = join(__dirname, ".venv", "bin", "python3");
+
+/** Path to the mic-vpio binary (required for local TTS) */
+const MIC_VPIO_PATH = join(__dirname, "mic-vpio");
+
+// ============================================================================
+// INTERFACES
+// ============================================================================
+
+/**
+ * Metadata about a TTS provider for display in the dashboard.
+ */
+export interface TtsProviderInfo {
+  /** Provider type identifier */
+  type: TtsProviderType;
+  /** Human-readable provider name */
+  name: string;
+  /** Short description of the provider */
+  description: string;
+  /** Platform required for this provider (undefined = any platform) */
+  requiresPlatform?: "darwin";
+  /** Environment variable name for the API key (undefined = no key needed) */
+  requiresApiKey?: string;
+}
+
+/**
+ * Options for creating a TTS player via the provider factory.
+ */
+export interface CreateTtsOptions {
+  /** Provider configuration (which provider + per-provider settings) */
+  providerConfig: TtsProviderConfig;
+  /** Writable stream for PCM audio output */
+  speakerInput: Writable;
+  /** Callback to clear the playback buffer on interruption */
+  interruptPlayback: () => void;
+  /** Callback to resume playback after an interrupt */
+  resumePlayback: () => void;
+}
+
+// ============================================================================
+// MAIN HANDLERS
+// ============================================================================
+
+/**
+ * Create a TtsPlayer for the configured provider.
+ * Routes to the local Kokoro provider or ElevenLabs cloud provider.
+ *
+ * @param options - Provider config, speaker stream, and playback callbacks
+ * @returns A TtsPlayer instance ready for playback
+ * @throws Error if the provider is not implemented
+ */
+export async function createTtsForProvider(options: CreateTtsOptions): Promise<TtsPlayer> {
+  const { providerConfig, speakerInput, interruptPlayback, resumePlayback } = options;
+
+  switch (providerConfig.provider) {
+    case "local":
+      return createLocalTts({
+        model: providerConfig.local.model,
+        voice: providerConfig.local.voice,
+        speakerInput,
+        interruptPlayback,
+        resumePlayback,
+      });
+
+    case "elevenlabs":
+      return createElevenlabsTts({
+        apiKey: providerConfig.elevenlabs.apiKey,
+        voiceId: providerConfig.elevenlabs.voiceId,
+        modelId: providerConfig.elevenlabs.modelId,
+        speakerInput,
+        interruptPlayback,
+        resumePlayback,
+      });
+
+    default:
+      throw new Error(`Unknown TTS provider: ${providerConfig.provider}`);
+  }
+}
+
+/**
+ * Check whether a TTS provider is ready to use.
+ *
+ * Local: checks macOS platform, Python venv exists, mic-vpio binary exists.
+ * ElevenLabs: checks ELEVENLABS_API_KEY is set in .env.
+ *
+ * @param providerType - The provider to check
+ * @returns Readiness status with reason if not ready
+ */
+export async function getTtsProviderStatus(providerType: TtsProviderType): Promise<ProviderStatus> {
+  switch (providerType) {
+    case "local": {
+      if (process.platform !== "darwin") {
+        return { ready: false, reason: "unsupported_platform", detail: "Local TTS requires macOS with Apple Silicon" };
+      }
+      if (!existsSync(PYTHON_VENV_PATH)) {
+        return { ready: false, reason: "not_installed", detail: "Python venv not found at " + PYTHON_VENV_PATH };
+      }
+      if (!existsSync(MIC_VPIO_PATH)) {
+        return { ready: false, reason: "not_installed", detail: "mic-vpio binary not found at " + MIC_VPIO_PATH };
+      }
+      return { ready: true };
+    }
+
+    case "elevenlabs": {
+      const env = await readEnv();
+      if (!env.ELEVENLABS_API_KEY) {
+        return { ready: false, reason: "missing_api_key", detail: "ELEVENLABS_API_KEY is not set in .env" };
+      }
+      return { ready: true };
+    }
+
+    default:
+      throw new Error(`Unknown TTS provider: ${providerType}`);
+  }
+}
+
+/**
+ * Get the list of all known TTS providers with metadata.
+ *
+ * @returns Static array of TTS provider info
+ */
+export function getAvailableTtsProviders(): TtsProviderInfo[] {
+  return [
+    {
+      type: "local",
+      name: "Local Kokoro",
+      description: "On-device TTS via mlx-audio (requires macOS + Apple Silicon)",
+      requiresPlatform: "darwin",
+    },
+    {
+      type: "elevenlabs",
+      name: "ElevenLabs",
+      description: "Cloud TTS via ElevenLabs streaming API",
+      requiresApiKey: "ELEVENLABS_API_KEY",
+    },
+  ];
+}

--- a/sidecar/tts.ts
+++ b/sidecar/tts.ts
@@ -1,5 +1,5 @@
 /**
- * Local text-to-speech via mlx-audio (Chatterbox Turbo) with VPIO playback.
+ * Local Kokoro TTS provider via mlx-audio with VPIO playback.
  *
  * Spawns a persistent Python subprocess (tts-server.py) that loads the TTS model
  * once on the Apple Silicon GPU via MLX, then generates audio on demand. Text is
@@ -104,7 +104,7 @@ const MIN_SENTENCE_LENGTH = 20;
  * @returns A TtsPlayer instance ready for playback
  * @throws Error if subprocess fails to start or model fails to load
  */
-export async function createTts(config: TtsConfig): Promise<TtsPlayer> {
+export async function createLocalTts(config: TtsConfig): Promise<TtsPlayer> {
   const cmd = config.serverCommand ?? [PYTHON_BIN, TTS_SERVER_SCRIPT, config.model, config.voice];
 
   const proc = spawn(cmd[0], cmd.slice(1), {
@@ -429,7 +429,7 @@ function readExactly(stream: NodeJS.ReadableStream, size: number): Promise<Buffe
  * @param stream - The VPIO speaker writable stream
  * @param pcmBuffer - Raw PCM bytes to write
  */
-function writePcm(stream: Writable, pcmBuffer: Buffer): Promise<void> {
+export function writePcm(stream: Writable, pcmBuffer: Buffer): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const ok = stream.write(pcmBuffer, (err: Error | null | undefined) => {
       if (err) reject(err);
@@ -449,7 +449,7 @@ function writePcm(stream: Writable, pcmBuffer: Buffer): Promise<void> {
  * @param texts - Async iterable of TextChunk from the narrator
  * @yields Complete sentences ready for TTS
  */
-async function* bufferSentences(texts: AsyncIterable<TextChunk>): AsyncGenerator<string> {
+export async function* bufferSentences(texts: AsyncIterable<TextChunk>): AsyncGenerator<string> {
   let buffer = "";
 
   for await (const raw of texts) {

--- a/sidecar/twilio-server.ts
+++ b/sidecar/twilio-server.ts
@@ -32,6 +32,7 @@ import type { IncomingMessage, ServerResponse } from "http";
 import type { Duplex } from "stream";
 import type { WebSocket } from "ws";
 import type { VoiceSession } from "./voice-session.js";
+import type { TtsProviderConfig, SttProviderConfig, TtsProviderType, SttProviderType } from "./types.js";
 
 // ============================================================================
 // CONSTANTS
@@ -43,13 +44,33 @@ const DEFAULT_PORT = 8080;
 /** Interruption threshold for phone calls (higher than local mic due to no VPIO echo cancellation) */
 const PHONE_INTERRUPTION_THRESHOLD_MS = 2000;
 
+/** Read provider selection and ElevenLabs config from environment */
+const TTS_PROVIDER = (process.env.TTS_PROVIDER ?? "local") as TtsProviderType;
+const STT_PROVIDER = (process.env.STT_PROVIDER ?? "local") as SttProviderType;
+const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY ?? "";
+const ELEVENLABS_VOICE_ID = process.env.ELEVENLABS_VOICE_ID ?? "JBFqnCBsd6RMkjVDRZzb";
+const ELEVENLABS_MODEL_ID = process.env.ELEVENLABS_MODEL_ID ?? "eleven_turbo_v2_5";
+const ELEVENLABS_STT_MODEL_ID = process.env.ELEVENLABS_STT_MODEL_ID ?? "scribe_v1";
+
+/** TTS provider configuration built from env vars */
+const ttsProvider: TtsProviderConfig = {
+  provider: TTS_PROVIDER,
+  local: { model: "prince-canuma/Kokoro-82M", voice: "af_heart" },
+  elevenlabs: { apiKey: ELEVENLABS_API_KEY, voiceId: ELEVENLABS_VOICE_ID, modelId: ELEVENLABS_MODEL_ID },
+};
+
+/** STT provider configuration built from env vars */
+const sttProvider: SttProviderConfig = {
+  provider: STT_PROVIDER,
+  local: { modelPath: join(homedir(), ".claude-voice-models", "whisper-small") },
+  elevenlabs: { apiKey: ELEVENLABS_API_KEY, modelId: ELEVENLABS_STT_MODEL_ID },
+};
+
 /** Default voice session config for phone calls (same as index.ts DEFAULT_CONFIG but with phone-tuned threshold) */
 const DEFAULT_CONFIG = {
   stopPhrase: "stop listening",
-  sttModelPath: join(homedir(), ".claude-voice-models", "whisper-small"),
-  ttsModel: "prince-canuma/Kokoro-82M",
-  ttsVoice: "af_heart",
-  modelCacheDir: join(homedir(), ".claude-voice-models"),
+  ttsProvider,
+  sttProvider,
   interruptionThresholdMs: PHONE_INTERRUPTION_THRESHOLD_MS,
   endpointing: {
     silenceThresholdMs: 700,

--- a/sidecar/types.ts
+++ b/sidecar/types.ts
@@ -208,3 +208,52 @@ export interface VoiceLoopState {
   /** Active Claude session ID, or null if no session is active */
   sessionId: string | null;
 }
+
+// ============================================================================
+// PROVIDER TYPES
+// ============================================================================
+
+/** Available TTS provider backends */
+export type TtsProviderType = "local" | "elevenlabs";
+
+/** Available STT provider backends */
+export type SttProviderType = "local" | "elevenlabs";
+
+/**
+ * Readiness status for a provider.
+ * Returned by getTtsProviderStatus / getSttProviderStatus.
+ */
+export interface ProviderStatus {
+  /** Whether the provider is ready to use */
+  ready: boolean;
+  /** Reason the provider is not ready (only present when ready is false) */
+  reason?: "not_installed" | "missing_api_key" | "unsupported_platform";
+  /** Human-readable detail about why the provider is not ready */
+  detail?: string;
+}
+
+/**
+ * Configuration that selects a TTS provider and holds per-provider settings.
+ * Built from environment variables in each entry point.
+ */
+export interface TtsProviderConfig {
+  /** Which TTS provider to use */
+  provider: TtsProviderType;
+  /** Settings for the local Kokoro TTS provider */
+  local: { model: string; voice: string };
+  /** Settings for the ElevenLabs TTS provider */
+  elevenlabs: { apiKey: string; voiceId: string; modelId: string };
+}
+
+/**
+ * Configuration that selects an STT provider and holds per-provider settings.
+ * Built from environment variables in each entry point.
+ */
+export interface SttProviderConfig {
+  /** Which STT provider to use */
+  provider: SttProviderType;
+  /** Settings for the local Whisper STT provider */
+  local: { modelPath: string };
+  /** Settings for the ElevenLabs STT provider */
+  elevenlabs: { apiKey: string; modelId: string };
+}

--- a/sidecar/voice-loop-bugs.test.ts
+++ b/sidecar/voice-loop-bugs.test.ts
@@ -17,7 +17,7 @@ import { PassThrough } from "stream";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
-import { createTts } from "./tts.js";
+import { createLocalTts } from "./tts.js";
 import { createClaudeSession } from "./claude-session.js";
 import type { TtsConfig, TextChunk, ClaudeSessionConfig, ClaudeStreamEvent } from "./types.js";
 
@@ -39,7 +39,7 @@ const TAGGED_MOCK_SERVER = join(__dirname, "mock-tts-server-tagged.mjs");
  * @returns Player, captured speaker output stream, and callback counters
  */
 async function createTaggedPlayer(): Promise<{
-  player: ReturnType<typeof createTts> extends Promise<infer T> ? T : never;
+  player: ReturnType<typeof createLocalTts> extends Promise<infer T> ? T : never;
   speakerOutput: PassThrough;
   counts: { interrupt: number; resume: number };
 }> {
@@ -55,7 +55,7 @@ async function createTaggedPlayer(): Promise<{
     serverCommand: ["node", TAGGED_MOCK_SERVER],
   };
 
-  const player = await createTts(config);
+  const player = await createLocalTts(config);
   return { player, speakerOutput, counts };
 }
 
@@ -245,7 +245,7 @@ test("BUG: after interrupt, next speakStream should start playing within bounded
     serverCommand: ["node", TAGGED_MOCK_SERVER, "30", "100"],
   };
 
-  const player = await createTts(config);
+  const player = await createLocalTts(config);
 
   try {
     const firstStream = player.speakStream(singleSentence("First sentence."));
@@ -313,7 +313,7 @@ test("BUG: speakStream resolves before audio finishes when chunks arrive with ga
     serverCommand: ["node", TAGGED_MOCK_SERVER, "15", "1"],
   };
 
-  const player = await createTts(config);
+  const player = await createLocalTts(config);
 
   try {
     let lastWriteTime = 0;


### PR DESCRIPTION
# Add TTS/STT provider system with ElevenLabs support

## Todo

- [ ] Test local TTS setup flow from dashboard
- [ ] Test local STT setup flow from dashboard
- [ ] Test ElevenLabs TTS with real API key
- [ ] Test ElevenLabs STT with real API key
- [ ] Test switching providers mid-session (restart required)

## What

This PR makes TTS and STT modular. Users can now switch between local providers (Kokoro TTS, Whisper STT) and cloud providers (ElevenLabs) from the dashboard UI. Provider selection and configuration are persisted in `.env` and take effect on the next voice session.

The local model setup (Python venv, Whisper ONNX models, mic-vpio binary) is no longer done during `npm install`. Instead, it happens on-demand when the user clicks "Setup" in the dashboard, with live log output in a modal.

## Why

Local TTS/STT requires platform-specific binaries (macOS-only mic-vpio, espeak-ng) and large model downloads (~100MB Whisper). This made `npm install` slow and fail on unsupported platforms. Making providers pluggable lets users on any platform use cloud providers immediately, and only install local dependencies if they want to.

## How

**Provider abstraction**: Factory functions (`createTtsForProvider`, `createSttForProvider`) route to the correct implementation based on a config object. The existing `createTts`/`createStt` functions were renamed to `createLocalTts`/`createLocalStt` and are now one path through the factory.

**ElevenLabs TTS**: Streams PCM audio from the ElevenLabs streaming API at 24kHz. Reuses the existing `bufferSentences` and `writePcm` helpers from the local TTS module for playback.

**ElevenLabs STT**: Accumulates raw Float32Array audio chunks, encodes them as a WAV file in memory, and uploads via multipart/form-data to the ElevenLabs Scribe v2 API.

**On-demand setup**: The setup scripts (`setup-local-tts.js`, `setup-local-stt.js`) are extracted from the old `postinstall.js`. The dashboard spawns them as background child processes and streams their stdout/stderr to a temp log file. The frontend polls a status endpoint every 1.5s to show live output in a modal.

**Dashboard UI**: A new "Voice" tab in Settings shows TTS and STT provider sections with radio buttons. Providers that aren't ready (not installed, missing API key, unsupported platform) have disabled radio buttons. Action buttons open modals for setup (local) or configuration (ElevenLabs). Provider selection and config changes save to `.env` immediately.

## How to test

1. Delete local model files to simulate fresh state:
   - `rm -rf sidecar/.venv sidecar/mic-vpio ~/.claude-voice-models/whisper-small/`
2. Start the dashboard and go to Settings > Voice
3. Verify local providers show "Not Installed" with a "Setup" button
4. Click Setup on a local provider -- a modal should show live installation logs
5. After setup completes, the provider should show "Ready" and become selectable
6. For ElevenLabs: click "Configure", enter an API key, click Apply -- the provider status should update to "Ready"
7. Select a provider and start a voice session to verify it works end-to-end

## Tech debt and future work

- ElevenLabs STT uses batch upload (not streaming) -- for long utterances this adds latency since the entire audio buffer is sent at once after silence detection
- The API key is duplicated in both TTS and STT config modals since it is a shared credential -- editing it in one modal does not reflect in the other until the page reloads
- No validation that the ElevenLabs API key is actually valid before marking the provider as "Ready" -- it just checks if the env var is non-empty
- Provider status is checked server-side on each page load -- there is no websocket push when status changes (e.g. after setup completes in another tab)