### PR TITLE
Fix conductor.json setup script structure

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,3 +1,5 @@
 {
-  "setup": "ln -s \"$CONDUCTOR_ROOT_PATH/.env\" .env && npm install"
+  "scripts": {
+    "setup": "ln -s \"$CONDUCTOR_ROOT_PATH/.env\" .env && npm install"
+  }
 }


### PR DESCRIPTION
## Summary
- Nest the `setup` command under a `scripts` key to match the expected conductor.json schema

## Test plan
- [ ] Verify Conductor runs the setup script when initializing a workspace