### PR TITLE
Add Twilio test call button and auto-webhook updates

### DIFF
--- a/dashboard/routes/claude-md.ts
+++ b/dashboard/routes/claude-md.ts
@@ -30,7 +30,12 @@ export function claudeMdRoutes(): Hono {
 
   /** Read the CLAUDE.md file */
   app.get("/", async (c) => {
-    const content = await readFile(CLAUDE_MD_PATH, "utf-8");
+    let content: string;
+    try {
+      content = await readFile(CLAUDE_MD_PATH, "utf-8");
+    } catch {
+      return c.json({ content: "" });
+    }
     return c.json({ content });
   });
 

--- a/dashboard/routes/conversations.ts
+++ b/dashboard/routes/conversations.ts
@@ -54,7 +54,12 @@ export function conversationRoutes(): Hono {
 
   /** List all conversation sessions with summaries */
   app.get("/", async (c) => {
-    const files = await readdir(SESSIONS_DIR);
+    let files: string[];
+    try {
+      files = await readdir(SESSIONS_DIR);
+    } catch {
+      return c.json([]);
+    }
     const jsonlFiles = files.filter((f) => f.endsWith(".jsonl"));
 
     const summaries: ConversationSummary[] = [];

--- a/dashboard/routes/twilio.ts
+++ b/dashboard/routes/twilio.ts
@@ -9,6 +9,7 @@
  */
 
 import { Hono } from "hono";
+import twilioSdk from "twilio";
 import { readEnv } from "../../services/env.js";
 import { startTwilioServer, stopTwilioServer, getStatus } from "../../services/twilio-manager.js";
 import { startTunnel, stopTunnel, getTunnelUrl, isTunnelRunning } from "../../services/tunnel.js";
@@ -114,6 +115,44 @@ export function twilioRoutes(): Hono {
     );
 
     return c.json({ numbers });
+  });
+
+  /** Place a test call to verify Twilio setup */
+  app.post("/test-call", async (c) => {
+    const body = await c.req.json<{ to: string }>();
+    const to = body.to?.trim();
+    if (!to) {
+      return c.json({ error: "Phone number is required" }, 400);
+    }
+
+    const envVars = await readEnv();
+    const accountSid = envVars.TWILIO_ACCOUNT_SID;
+    const authToken = envVars.TWILIO_AUTH_TOKEN;
+
+    if (!accountSid || !authToken) {
+      return c.json({ error: "Twilio credentials not configured" }, 400);
+    }
+
+    try {
+      const client = twilioSdk(accountSid, authToken);
+
+      // Get the first Twilio phone number to use as caller ID
+      const numbers = await client.incomingPhoneNumbers.list({ limit: 1 });
+      if (numbers.length === 0) {
+        return c.json({ error: "No Twilio phone numbers found on this account" }, 400);
+      }
+
+      const call = await client.calls.create({
+        to,
+        from: numbers[0].phoneNumber,
+        twiml: '<Response><Say>This is a test call from your voice assistant. If you can hear this, your Twilio setup is working correctly. Goodbye!</Say></Response>',
+      });
+
+      return c.json({ success: true, callSid: call.sid });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to place call";
+      return c.json({ error: message }, 500);
+    }
   });
 
   return app;

--- a/dashboard/src/components/McpServersPanel.tsx
+++ b/dashboard/src/components/McpServersPanel.tsx
@@ -85,10 +85,10 @@ export function McpServersPanel({ twilioRunning, browserCallRunning }: McpServer
         <p style={{ fontSize: 13, color: "var(--text-secondary)", marginBottom: 20 }}>Connect external services to enable voice calling capabilities.</p>
 
         <div style={{ display: "flex", gap: 12 }}>
-          {/* <button className="btn-integration" onClick={() => setShowTwilioModal(true)}>
+          <button className="btn-integration" onClick={() => setShowTwilioModal(true)}>
             <span className={`integration-dot${twilioRunning ? " running" : ""}`} />
             Twilio
-          </button> */}
+          </button>
           <button className="btn-integration" onClick={() => setShowBrowserCallModal(true)}>
             <span className={`integration-dot${browserCallRunning ? " running" : ""}`} />
             Browser Call from Anywhere

--- a/dashboard/src/components/TwilioPanel.tsx
+++ b/dashboard/src/components/TwilioPanel.tsx
@@ -50,6 +50,8 @@ export function TwilioPanel({ onClose }: TwilioPanelProps) {
   const [actionText, setActionText] = useState("");
   const [enabled, setEnabled] = useState(false);
   const [toggling, setToggling] = useState(false);
+  const [testNumber, setTestNumber] = useState("");
+  const [testCallStatus, setTestCallStatus] = useState("");
 
   // Load current settings, integration state, and check cloudflared on mount
   useEffect(() => {
@@ -268,6 +270,41 @@ export function TwilioPanel({ onClose }: TwilioPanelProps) {
             ) : (
               "Set your Account SID and Auth Token to fetch your phone number."
             )}
+          </div>
+        </div>
+
+        <hr className="setup-divider" />
+
+        {/* Test Call */}
+        <div className="setup-step">
+          <div className="setup-step-title"><span className="setup-step-number">7</span>Test your setup</div>
+          <div className="setup-step-desc">
+            Enter your phone number and we'll call you with a test message.
+            {testCallStatus && <div style={{ color: testCallStatus.startsWith("Error") ? "#d73a49" : "#2ea043", marginTop: 4, fontSize: 12 }}>{testCallStatus}</div>}
+          </div>
+          <div className="setup-paste-row">
+            <input
+              type="tel"
+              placeholder="+1234567890"
+              value={testNumber}
+              onChange={(e) => setTestNumber(e.target.value)}
+            />
+            <button
+              disabled={!testNumber.trim() || !accountSid || !authToken || testCallStatus === "Calling..."}
+              onClick={async () => {
+                setTestCallStatus("Calling...");
+                try {
+                  await post("/api/twilio/test-call", { to: testNumber.trim() });
+                  setTestCallStatus("Call initiated! Check your phone.");
+                } catch (err) {
+                  const message = err instanceof Error ? err.message : (err as { message?: string })?.message || "Failed";
+                  setTestCallStatus(`Error: ${message}`);
+                }
+                setTimeout(() => setTestCallStatus(""), 6000);
+              }}
+            >
+              Test Call
+            </button>
           </div>
         </div>
       </div>

--- a/run.ts
+++ b/run.ts
@@ -8,7 +8,7 @@
 
 import { startDashboard } from "./dashboard/server.js";
 import { readEnv } from "./services/env.js";
-import { startTunnel, isTunnelRunning } from "./services/tunnel.js";
+import { startTunnel, isTunnelRunning, getTunnelUrl } from "./services/tunnel.js";
 import { startTwilioServer } from "./services/twilio-manager.js";
 import { startBrowserCallServer } from "./services/browser-call-manager.js";
 
@@ -38,7 +38,7 @@ async function main(): Promise<void> {
       if (!isTunnelRunning()) {
         await startTunnel(tunnelPort);
       }
-      await startTwilioServer(port, undefined);
+      await startTwilioServer(port, getTunnelUrl() ?? undefined);
     } catch (err) {
       console.error(`Twilio auto-start failed: ${err}`);
     }

--- a/services/twilio-manager.ts
+++ b/services/twilio-manager.ts
@@ -54,19 +54,40 @@ export async function startTwilioServer(dashboardPort: number, tunnelUrl?: strin
     throw new Error("TWILIO_AUTH_TOKEN is not set in .env");
   }
 
-  // Update TwiML App voice URL if configured
-  const twimlAppSid = envVars.TWILIO_TWIML_APP_SID;
   const accountSid = envVars.TWILIO_ACCOUNT_SID;
-  if (tunnelUrl && twimlAppSid && accountSid && envVars.TWILIO_AUTH_TOKEN) {
+  const webhookUrl = tunnelUrl ? `${tunnelUrl}/twilio/incoming-call` : null;
+
+  if (tunnelUrl && accountSid && envVars.TWILIO_AUTH_TOKEN) {
+    const client = twilioSdk(accountSid, envVars.TWILIO_AUTH_TOKEN);
+
+    // Update TwiML App voice URL if configured
+    const twimlAppSid = envVars.TWILIO_TWIML_APP_SID;
+    if (twimlAppSid) {
+      try {
+        await client.applications(twimlAppSid).update({
+          voiceUrl: webhookUrl!,
+          voiceMethod: "POST",
+        });
+        console.log(`Updated TwiML App voice URL to ${webhookUrl}`);
+      } catch (err) {
+        console.error(`Failed to update TwiML App voice URL: ${err}`);
+      }
+    }
+
+    // Update all phone numbers on the account to point to the new webhook URL
     try {
-      const client = twilioSdk(accountSid, envVars.TWILIO_AUTH_TOKEN);
-      await client.applications(twimlAppSid).update({
-        voiceUrl: `${tunnelUrl}/twilio/incoming-call`,
-        voiceMethod: "POST",
-      });
-      console.log(`Updated TwiML App voice URL to ${tunnelUrl}/twilio/incoming-call`);
+      const numbers = await client.incomingPhoneNumbers.list();
+      for (const num of numbers) {
+        await client.incomingPhoneNumbers(num.sid).update({
+          voiceUrl: webhookUrl!,
+          voiceMethod: "POST",
+        });
+      }
+      if (numbers.length > 0) {
+        console.log(`Updated ${numbers.length} phone number(s) webhook to ${webhookUrl}`);
+      }
     } catch (err) {
-      console.error(`Failed to update TwiML App voice URL: ${err}`);
+      console.error(`Failed to update phone number webhooks: ${err}`);
     }
   }
 

--- a/sidecar/twilio-audio.ts
+++ b/sidecar/twilio-audio.ts
@@ -317,8 +317,8 @@ export function twilioPayloadToFloat32(base64Payload: string): Float32Array {
  * @returns Base64-encoded mulaw audio at 8kHz for Twilio
  */
 export function pcm24kToTwilioPayload(pcmBuffer: Buffer): string {
-  // Read int16 samples from the PCM buffer
-  const sampleCount = pcmBuffer.length / 2;
+  // Read int16 samples from the PCM buffer (floor to handle odd-length buffers)
+  const sampleCount = Math.floor(pcmBuffer.length / 2);
   const pcm24k = new Int16Array(sampleCount);
   for (let i = 0; i < sampleCount; i++) {
     pcm24k[i] = pcmBuffer.readInt16LE(i * 2);

--- a/sidecar/twilio-server.ts
+++ b/sidecar/twilio-server.ts
@@ -213,6 +213,8 @@ function handleIncomingCall(
     const signature = req.headers["x-twilio-signature"] as string;
     if (!signature || !twilio.validateRequest(authToken, signature, validationUrl, params)) {
       console.log("Rejected incoming call: invalid Twilio signature");
+      console.log("  validationUrl:", validationUrl);
+      console.log("  signature:", signature);
       res.writeHead(403, { "Content-Type": "text/plain" });
       res.end("Forbidden");
       return;


### PR DESCRIPTION
## What

Added a test call feature to the Twilio settings panel that lets users verify their Twilio setup by calling their own phone number. The system now automatically updates all Twilio phone number webhooks when the tunnel starts, eliminating the need to manually reconfigure webhook URLs after each restart.

Fixed several startup errors that occurred when files were missing (conversations.ts, claude-md.ts, audio buffer overflow).

## Why

The Twilio setup process was cumbersome: after restarting, the cloudflared tunnel generates a new public URL, but the Twilio phone number webhooks still point to the old URL. Users had to manually update the webhook URLs via the Twilio console each time they restarted.

The test call button provides immediate feedback that the entire setup works without requiring a manual phone call.

## How

**Test call endpoint** (`POST /twilio/test-call`):
- Reads user's phone number from request body
- Fetches the first Twilio phone number on the account to use as caller ID
- Creates an outbound call with a TwiML response that plays a test message
- Returns the call SID or error

**Auto-webhook update**:
- When Twilio server starts, reads the current tunnel URL from `getTunnelUrl()`
- Updates all phone numbers on the account to point their voice webhook to the new tunnel URL
- Also updates the TwiML App voice URL if configured
- Logs success/failure for each update

**Startup error fixes**:
- `conversations.ts`: Added try/catch around `readdir(SESSIONS_DIR)` to return empty array if directory doesn't exist
- `claude-md.ts`: Added try/catch around `readFile(CLAUDE_MD_PATH)` to return empty string if file doesn't exist  
- `twilio-audio.ts`: Fixed buffer overflow by using `Math.floor(pcmBuffer.length / 2)` instead of division result (which could be non-integer)
- `run.ts`: Fixed auto-start to pass the actual tunnel URL instead of `undefined` to `startTwilioServer()`

## How to test

1. Go to Settings > Integrations > Twilio
2. If Twilio is running, the tunnel URL should display in Step 4
3. Scroll to Step 7 "Test your setup"
4. Enter your phone number and click "Test Call"
5. Your phone should ring with a test message ("This is a test call from your voice assistant...")
6. Restart voicecc and verify that the Twilio server automatically updates the phone number webhooks (check logs for "Updated X phone number(s) webhook")

## Tech debt and future work

The tunnel URL changes on every restart due to how cloudflared quick tunnels work. A production deployment would use a persistent tunnel with a fixed domain instead.