### PR TITLE
fix ElevenLabs TTS hiss caused by unaligned PCM chunks

### DIFF
--- a/sidecar/tts-elevenlabs-hiss.test.ts
+++ b/sidecar/tts-elevenlabs-hiss.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests that ElevenLabs TTS writes sample-aligned PCM to the speaker stream.
+ *
+ * ElevenLabs streams raw PCM (16-bit, 24kHz mono) over HTTP. The fetch
+ * response body yields chunks at arbitrary byte boundaries (TCP packets).
+ * Each chunk is written to the speaker stream, which for the browser path
+ * becomes a separate WebSocket message. The browser interprets each message
+ * as Int16Array -- if a chunk has an odd byte count, a sample is split and
+ * all subsequent audio is corrupted (hiss/static).
+ *
+ * Run: npx tsx --test sidecar/tts-elevenlabs-hiss.test.ts
+ */
+
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { PassThrough } from "stream";
+
+import { createElevenlabsTts } from "./tts-elevenlabs.js";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+/** Sample rate of ElevenLabs PCM output */
+const SAMPLE_RATE = 24000;
+
+/** Bytes per sample (16-bit) */
+const BYTES_PER_SAMPLE = 2;
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Generate a buffer of raw 16-bit signed LE PCM (440Hz sine wave).
+ *
+ * @param sampleCount - Number of samples to generate
+ * @returns Buffer of int16 LE PCM
+ */
+function generateSineWavePcm(sampleCount: number): Buffer {
+  const buf = Buffer.alloc(sampleCount * BYTES_PER_SAMPLE);
+
+  for (let i = 0; i < sampleCount; i++) {
+    const t = i / SAMPLE_RATE;
+    const int16 = Math.round(Math.sin(2 * Math.PI * 440 * t) * 32767);
+    buf.writeInt16LE(int16, i * BYTES_PER_SAMPLE);
+  }
+
+  return buf;
+}
+
+/**
+ * Create a mock fetch Response whose body streams the given PCM buffer
+ * split into chunks at the specified byte offsets (simulating arbitrary
+ * HTTP chunked transfer boundaries).
+ *
+ * @param pcm - Full PCM buffer to stream
+ * @param splitOffsets - Byte offsets at which to split (e.g. [1001, 2000])
+ * @returns A Response object with a streaming body
+ */
+function createMockResponse(pcm: Buffer, splitOffsets: number[]): Response {
+  const chunks: Uint8Array[] = [];
+  let offset = 0;
+
+  for (const splitAt of splitOffsets) {
+    if (offset >= pcm.byteLength) break;
+    chunks.push(new Uint8Array(pcm.subarray(offset, Math.min(splitAt, pcm.byteLength))));
+    offset = splitAt;
+  }
+
+  if (offset < pcm.byteLength) {
+    chunks.push(new Uint8Array(pcm.subarray(offset)));
+  }
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(stream, { status: 200 });
+}
+
+/**
+ * Stub global fetch to return a mock response, run the callback, then restore.
+ *
+ * @param mockResponse - The Response to return from fetch
+ * @param fn - Async function to run while fetch is stubbed
+ */
+async function withMockFetch(mockResponse: Response, fn: () => Promise<void>): Promise<void> {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => mockResponse;
+
+  try {
+    await fn();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+// ============================================================================
+// TESTS
+// ============================================================================
+
+/**
+ * Every write to the speaker stream must have an even byte count so the
+ * browser can interpret it as Int16Array without truncating or misaligning.
+ */
+test("ElevenLabs chunks written to speaker must be sample-aligned (even byte count)", async () => {
+  const pcm = generateSineWavePcm(2400); // 0.1s of audio = 4800 bytes
+  const speakerOutput = new PassThrough();
+
+  // Split at odd byte offsets to simulate arbitrary HTTP chunk boundaries
+  const mockResponse = createMockResponse(pcm, [1001, 2000, 3333, 4001]);
+
+  const player = await createElevenlabsTts({
+    apiKey: "test-key",
+    voiceId: "test-voice",
+    modelId: "test-model",
+    speakerInput: speakerOutput,
+    interruptPlayback: () => {},
+    resumePlayback: () => {},
+  });
+
+  // Collect all chunks written to the speaker stream
+  const writtenChunks: Buffer[] = [];
+  speakerOutput.on("data", (chunk: Buffer) => {
+    writtenChunks.push(Buffer.from(chunk));
+  });
+
+  await withMockFetch(mockResponse, () => player.speak("Hello world"));
+
+  // Every chunk written to the speaker must be sample-aligned
+  const oddChunks = writtenChunks.filter((c) => c.byteLength % BYTES_PER_SAMPLE !== 0);
+
+  assert.equal(
+    oddChunks.length,
+    0,
+    `${oddChunks.length} of ${writtenChunks.length} chunks written to speaker had odd byte length ` +
+    `(${oddChunks.map((c) => c.byteLength).join(", ")} bytes). ` +
+    `Odd-length chunks split 16-bit PCM samples, causing hiss in browser playback.`
+  );
+});
+
+/**
+ * Sample alignment must not lose audio data. The total bytes written to the
+ * speaker must equal the original PCM size.
+ */
+test("total bytes written to speaker must equal source PCM size", async () => {
+  const pcm = generateSineWavePcm(2400); // 0.1s = 4800 bytes
+  const speakerOutput = new PassThrough();
+
+  // Odd splits that would cause byte loss if alignment just truncates
+  const mockResponse = createMockResponse(pcm, [1001, 2000, 3333, 4001]);
+
+  const player = await createElevenlabsTts({
+    apiKey: "test-key",
+    voiceId: "test-voice",
+    modelId: "test-model",
+    speakerInput: speakerOutput,
+    interruptPlayback: () => {},
+    resumePlayback: () => {},
+  });
+
+  const writtenChunks: Buffer[] = [];
+  speakerOutput.on("data", (chunk: Buffer) => {
+    writtenChunks.push(Buffer.from(chunk));
+  });
+
+  await withMockFetch(mockResponse, () => player.speak("Hello world"));
+
+  const totalWritten = writtenChunks.reduce((sum, c) => sum + c.byteLength, 0);
+
+  assert.equal(
+    totalWritten,
+    pcm.byteLength,
+    `Expected ${pcm.byteLength} bytes written to speaker, got ${totalWritten}. ` +
+    `Sample alignment must carry over leftover bytes, not drop them.`
+  );
+});

--- a/sidecar/tts-elevenlabs.ts
+++ b/sidecar/tts-elevenlabs.ts
@@ -297,23 +297,44 @@ export async function createElevenlabsTts(config: ElevenlabsTtsConfig): Promise<
 // ============================================================================
 
 /**
- * Read chunks from a fetch Response body as an async iterable.
- * The response body is a ReadableStream of Uint8Array chunks.
+ * Read chunks from a fetch Response body as an async iterable, ensuring each
+ * yielded chunk is aligned to 16-bit sample boundaries (even byte count).
+ *
+ * HTTP streaming splits the byte stream at arbitrary TCP packet boundaries.
+ * A chunk with an odd byte count splits a 16-bit PCM sample in half. Downstream
+ * consumers (browser WebSocket -> Int16Array) interpret each chunk independently,
+ * so a misaligned chunk corrupts all its samples (heard as hiss/static).
  *
  * @param response - The fetch Response to read from
- * @yields Uint8Array chunks of raw PCM audio data
+ * @yields Buffer chunks of sample-aligned raw PCM audio data
  */
-async function* readResponseChunks(response: Response): AsyncGenerator<Uint8Array> {
+async function* readResponseChunks(response: Response): AsyncGenerator<Buffer> {
   const body = response.body;
   if (!body) throw new Error("ElevenLabs TTS response has no body");
 
   const reader = body.getReader();
+  let leftover: Buffer | null = null;
+
   try {
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
-      if (value) yield value;
+      if (!value) continue;
+
+      let chunk = leftover ? Buffer.concat([leftover, value]) : Buffer.from(value);
+      leftover = null;
+
+      // Hold back the last byte if odd length (split sample)
+      if (chunk.byteLength % 2 !== 0) {
+        leftover = Buffer.from(chunk.subarray(chunk.byteLength - 1));
+        chunk = chunk.subarray(0, chunk.byteLength - 1);
+      }
+
+      if (chunk.byteLength > 0) yield chunk;
     }
+
+    // Flush any remaining byte (only happens with malformed PCM)
+    if (leftover && leftover.byteLength > 0) yield leftover;
   } finally {
     reader.releaseLock();
   }


### PR DESCRIPTION
## Summary

ElevenLabs streams raw PCM over HTTP at arbitrary byte boundaries (TCP packets). When an HTTP response chunk has an odd byte count, a 16-bit sample is split across two chunks. The browser then interprets each WebSocket message independently as Int16Array, corrupting all samples after the split (heard as hiss/static between chunks).

This fix ensures every chunk written to the speaker stream is sample-aligned (even byte count) by carrying over leftover bytes between chunks in the `readResponseChunks` generator.

## Changes

- **sidecar/tts-elevenlabs.ts**: Align HTTP chunks to 16-bit sample boundaries by holding back odd-length bytes and prepending them to the next chunk
- **sidecar/tts-elevenlabs-hiss.test.ts**: Add regression tests verifying speaker writes are sample-aligned and no audio data is lost

## Test Plan

- All existing audio tests pass
- New tests verify chunks are always even-length and total bytes are preserved with odd-split HTTP responses