### PR TITLE
Remove unused TwiML app configuration

### DIFF
--- a/services/twilio-manager.ts
+++ b/services/twilio-manager.ts
@@ -36,8 +36,8 @@ let twilioRunning = false;
 
 /**
  * Start the Twilio voice server.
- * Reads .env for TWILIO_AUTH_TOKEN. If tunnelUrl and TwiML app SID exist,
- * updates the TwiML app voice URL via Twilio SDK.
+ * Reads .env for TWILIO_AUTH_TOKEN. If tunnelUrl exists, updates phone number
+ * webhooks via Twilio SDK.
  * Spawns twilio-server.ts as a child process with DASHBOARD_PORT env var.
  *
  * @param dashboardPort - The dashboard server port (for proxying)
@@ -59,20 +59,6 @@ export async function startTwilioServer(dashboardPort: number, tunnelUrl?: strin
 
   if (tunnelUrl && accountSid && envVars.TWILIO_AUTH_TOKEN) {
     const client = twilioSdk(accountSid, envVars.TWILIO_AUTH_TOKEN);
-
-    // Update TwiML App voice URL if configured
-    const twimlAppSid = envVars.TWILIO_TWIML_APP_SID;
-    if (twimlAppSid) {
-      try {
-        await client.applications(twimlAppSid).update({
-          voiceUrl: webhookUrl!,
-          voiceMethod: "POST",
-        });
-        console.log(`Updated TwiML App voice URL to ${webhookUrl}`);
-      } catch (err) {
-        console.error(`Failed to update TwiML App voice URL: ${err}`);
-      }
-    }
 
     // Update all phone numbers on the account to point to the new webhook URL
     try {


### PR DESCRIPTION
Remove TwiML app voice URL update logic that was not being used. The code for updating TwiML app SID is no longer needed, and phone number webhook updates remain as the primary webhook configuration method.

## What
Removed the TwiML app configuration block from startTwilioServer(), including the try-catch for updating the TwiML app voice URL and the associated environment variable check. Updated JSDoc to reflect that the function now only handles phone number webhook updates.

## Why
The TwiML app configuration was not in use. Removing it reduces code complexity and maintenance burden by eliminating code paths that serve no purpose.

## How
Deleted lines 63-75 from services/twilio-manager.ts that handled TwiML app updates. The phone number webhook update logic (lines 77-91) remains unchanged and continues to work as the primary webhook configuration mechanism.