### PR TITLE
Add version check with update banner

### DIFF
--- a/dashboard/routes/version.ts
+++ b/dashboard/routes/version.ts
@@ -1,0 +1,102 @@
+/**
+ * Version check API route.
+ *
+ * Compares the installed version against the latest on npm:
+ * - GET / -- returns { current, latest, updateAvailable }
+ * - Caches the npm lookup for 1 hour to avoid excessive requests
+ */
+
+import { Hono } from "hono";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const NPM_REGISTRY_URL = "https://registry.npmjs.org/voicecc/latest";
+
+// ============================================================================
+// CACHE
+// ============================================================================
+
+let cachedLatest: string | null = null;
+let cachedAt = 0;
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/**
+ * Read the installed version from package.json.
+ *
+ * @returns Current version string (e.g. "1.0.11")
+ */
+function getCurrentVersion(): string {
+  const pkg = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf-8"));
+  return pkg.version;
+}
+
+/**
+ * Fetch the latest published version from the npm registry.
+ * Returns cached value if within TTL.
+ *
+ * @returns Latest version string, or null if the fetch fails
+ */
+async function getLatestVersion(): Promise<string | null> {
+  if (cachedLatest && Date.now() - cachedAt < CACHE_TTL_MS) {
+    return cachedLatest;
+  }
+
+  try {
+    const res = await fetch(NPM_REGISTRY_URL);
+    if (!res.ok) return cachedLatest;
+    const data = (await res.json()) as { version: string };
+    cachedLatest = data.version;
+    cachedAt = Date.now();
+    return cachedLatest;
+  } catch {
+    return cachedLatest;
+  }
+}
+
+/**
+ * Compare two semver strings (e.g. "1.0.11" vs "1.0.12").
+ *
+ * @param a - First version
+ * @param b - Second version
+ * @returns -1 if a < b, 0 if equal, 1 if a > b
+ */
+function semverCompare(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] > pb[i]) return 1;
+    if (pb[i] > pa[i]) return -1;
+  }
+  return 0;
+}
+
+// ============================================================================
+// ROUTES
+// ============================================================================
+
+/**
+ * Create Hono route group for version checking.
+ *
+ * @returns Hono instance with GET / route
+ */
+export function versionRoutes(): Hono {
+  const app = new Hono();
+
+  app.get("/", async (c) => {
+    const current = getCurrentVersion();
+    const latest = await getLatestVersion();
+    const updateAvailable = latest !== null && semverCompare(current, latest) < 0;
+
+    return c.json({ current, latest, updateAvailable });
+  });
+
+  return app;
+}

--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -27,6 +27,7 @@ import { authRoutes } from "./routes/auth.js";
 import { integrationsRoutes, setDashboardPort as setIntegrationsDashboardPort } from "./routes/integrations.js";
 import { providersRoutes } from "./routes/providers.js";
 import { agentsRoutes } from "./routes/agents.js";
+import { versionRoutes } from "./routes/version.js";
 import { loadDeviceTokens } from "../server/services/device-pairing.js";
 
 // ============================================================================
@@ -61,6 +62,7 @@ function createApp(): Hono {
   app.route("/api/integrations", integrationsRoutes());
   app.route("/api/providers", providersRoutes());
   app.route("/api/agents", agentsRoutes());
+  app.route("/api/version", versionRoutes());
 
   // Status endpoint (user CLAUDE.md conflict check)
   app.get("/api/status", async (c) => {

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -8,10 +8,18 @@ export interface LayoutContext {
     authStatus: boolean | null;
 }
 
+interface VersionInfo {
+    current: string;
+    latest: string | null;
+    updateAvailable: boolean;
+}
+
 export function Layout() {
     const [twilioStatus, setTwilioStatus] = useState<TwilioStatus>({ running: false, tunnelUrl: null });
     const [browserCallStatus, setBrowserCallStatus] = useState<BrowserCallStatus>({ running: false, tunnelUrl: null });
     const [authStatus, setAuthStatus] = useState<boolean | null>(null);
+    const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
+    const [bannerDismissed, setBannerDismissed] = useState(false);
 
     useEffect(() => {
         const poll = () => {
@@ -29,10 +37,56 @@ export function Layout() {
             .catch(() => setAuthStatus(false));
     }, []);
 
+    useEffect(() => {
+        get<VersionInfo>("/api/version")
+            .then(setVersionInfo)
+            .catch(() => { });
+    }, []);
+
+    const showBanner = versionInfo?.updateAvailable && !bannerDismissed;
+
     return (
         <div style={{ display: "flex", height: "100vh" }}>
             <Sidebar twilioStatus={twilioStatus} browserCallStatus={browserCallStatus} authStatus={authStatus} />
             <div className="main" style={{ display: "flex", flexDirection: "column", height: "100vh", overflow: "hidden" }}>
+                {showBanner && (
+                    <div style={{
+                        padding: "8px 16px",
+                        background: "var(--bg-surface)",
+                        borderBottom: "1px solid var(--border-color)",
+                        fontSize: 12,
+                        color: "var(--text-secondary)",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        flexShrink: 0,
+                    }}>
+                        <span>
+                            Update available: <strong style={{ color: "var(--text-primary)" }}>v{versionInfo.latest}</strong> (current: v{versionInfo.current}).
+                            Run <code style={{
+                                background: "var(--bg-main)",
+                                padding: "1px 5px",
+                                fontFamily: '"SF Mono", "Fira Code", monospace',
+                                fontSize: 11,
+                                color: "var(--accent-color)",
+                            }}>npm install -g voicecc</code> to update.
+                        </span>
+                        <button
+                            onClick={() => setBannerDismissed(true)}
+                            style={{
+                                background: "none",
+                                border: "none",
+                                color: "var(--text-secondary)",
+                                cursor: "pointer",
+                                fontSize: 14,
+                                padding: "0 4px",
+                                lineHeight: 1,
+                            }}
+                        >
+                            x
+                        </button>
+                    </div>
+                )}
                 <Outlet context={{ authStatus } satisfies LayoutContext} />
             </div>
         </div>


### PR DESCRIPTION
## Summary

Adds automatic version checking to notify users when a new voicecc release is available. The dashboard now displays a dismissible banner at the top when an update is available, with instructions to upgrade via npm.

## What

- New `/api/version` endpoint that checks installed version against latest on npm registry
- Update banner in the dashboard layout that appears when a newer version is available
- 1-hour cache on npm registry lookups for performance
- Banner styled to match app design system with full light/dark mode support

## Why

Users running voicecc should be aware when updates are available. This provides non-intrusive notification without requiring them to manually check for new releases.

## How

Backend: The version endpoint reads package.json, fetches latest from npm registry (with 1-hour TTL cache), and returns comparison results using semver logic.

Frontend: The Layout component fetches this endpoint on mount, displays a banner if an update is available, and allows users to dismiss it. The banner is styled using CSS variables to match the monochromatic design system.

## How to test

1. Temporarily set package.json version to `1.0.0`
2. Start the server with `npm start`
3. The update banner should appear at the top showing v1.0.11 is available
4. Click the "x" button to dismiss (per session)
5. Revert package.json version to `1.0.11`

## Screenshots

Banner appears at top of dashboard with monospace font for install command, styled consistently with app design.