### PR TITLE
Add interactive first-run setup with password protection

### DIFF
--- a/bin/voicecc.js
+++ b/bin/voicecc.js
@@ -3,24 +3,132 @@
 /**
  * CLI entry point for the voicecc command.
  *
- * Copies CLAUDE.md on first run, then spawns the dashboard server.
+ * - On first run (no .env), launches an interactive setup wizard
+ * - Copies CLAUDE.md template on first run
+ * - Spawns the dashboard server
  */
 
 import { spawn } from "node:child_process";
 import { copyFileSync, existsSync } from "node:fs";
+import { writeFile, readFile } from "node:fs/promises";
+import { createInterface } from "node:readline";
+import { randomBytes } from "node:crypto";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PKG_ROOT = join(__dirname, "..");
 const TSX_BIN = join(PKG_ROOT, "node_modules", ".bin", "tsx");
+const ENV_PATH = join(PKG_ROOT, ".env");
 
 process.chdir(PKG_ROOT);
+
+// ============================================================================
+// SETUP WIZARD
+// ============================================================================
+
+/**
+ * Prompt the user for a single line of input.
+ *
+ * @param rl - readline interface
+ * @param question - the prompt text
+ * @returns the user's trimmed answer
+ */
+function ask(rl, question) {
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => resolve(answer.trim()));
+  });
+}
+
+/**
+ * Generate a cryptographically random password (24 URL-safe characters).
+ *
+ * @returns generated password string
+ */
+function generatePassword() {
+  return randomBytes(18).toString("base64url");
+}
+
+/**
+ * Run the first-run setup wizard.
+ * Prompts for ElevenLabs API key and dashboard password configuration.
+ * Writes results to .env.
+ */
+async function runSetupWizard() {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+  console.log("");
+  console.log("========================================");
+  console.log("       Welcome to VoiceCC Setup!        ");
+  console.log("========================================");
+  console.log("");
+
+  // ElevenLabs API key
+  console.log("VoiceCC uses ElevenLabs for speech recognition and text-to-speech.");
+  console.log("You can get a free API key at: https://elevenlabs.io");
+  console.log("");
+  const apiKey = await ask(rl, "Paste your ElevenLabs API key (or press Enter to skip): ");
+  if (!apiKey) {
+    console.log("Skipped. You can add it later from the dashboard.");
+  }
+
+  // Dashboard password
+  console.log("");
+  console.log("Would you like to protect your dashboard with a password?");
+  console.log("Anyone with access to the dashboard can control your voice agents.");
+  console.log("");
+  console.log("  1) Yes, generate a password for me (recommended)");
+  console.log("  2) No, leave it open (not recommended)");
+  console.log("");
+  const passwordChoice = await ask(rl, "Choose [1/2]: ");
+
+  let password = "";
+  if (passwordChoice === "2") {
+    console.log("");
+    console.log("WARNING: Your dashboard will be open to anyone who can reach it.");
+  } else {
+    password = generatePassword();
+    console.log("");
+    console.log("========================================");
+    console.log("  Your dashboard login (save this!)     ");
+    console.log("========================================");
+    console.log("");
+    console.log(`  Username: admin`);
+    console.log(`  Password: ${password}`);
+    console.log("");
+    console.log("  \x1b[31mThis will NOT be shown again.\x1b[0m");
+    console.log("  Your browser will ask for these when");
+    console.log("  you open the dashboard.");
+    console.log("========================================");
+    console.log("");
+    await ask(rl, "Have you saved the password? Press Enter to continue. ");
+  }
+
+  rl.close();
+
+  // Build .env content
+  const lines = [];
+  if (apiKey) lines.push(`ELEVENLABS_API_KEY=${apiKey}`);
+  if (password) lines.push(`DASHBOARD_PASSWORD=${password}`);
+  await writeFile(ENV_PATH, lines.join("\n") + "\n", "utf-8");
+
+  console.log("All done! Starting VoiceCC...");
+  console.log("");
+}
+
+// ============================================================================
+// MAIN ENTRYPOINT
+// ============================================================================
 
 // Copy CLAUDE.md template if available
 const claudeMdSrc = join("init", "CLAUDE.md");
 if (existsSync(claudeMdSrc)) {
   copyFileSync(claudeMdSrc, "CLAUDE.md");
+}
+
+// Run setup wizard on first run (no .env file)
+if (!existsSync(ENV_PATH)) {
+  await runSetupWizard();
 }
 
 // Start the dashboard

--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -8,6 +8,7 @@
  */
 
 import { Hono } from "hono";
+import { basicAuth } from "hono/basic-auth";
 import { serve } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { readFileSync } from "fs";
@@ -47,6 +48,12 @@ const USER_CLAUDE_MD_PATH = join(homedir(), ".claude", "CLAUDE.md");
  */
 function createApp(): Hono {
   const app = new Hono();
+
+  // Dashboard password protection (HTTP Basic Auth)
+  const dashboardPassword = process.env.DASHBOARD_PASSWORD;
+  if (dashboardPassword) {
+    app.use("*", basicAuth({ username: "admin", password: dashboardPassword }));
+  }
 
   // API route groups
   app.route("/api/claude-md", claudeMdRoutes());


### PR DESCRIPTION
Adds an interactive first-run setup wizard to the voicecc CLI that prompts users for their ElevenLabs API key and optionally generates a dashboard password. The dashboard is now protected with HTTP Basic Auth when a password is configured. Generated passwords are displayed once with a clear warning that they won't be shown again.