### PR TITLE
test(dashboard): Add HTTP Basic Auth regression tests

### DIFF
--- a/dashboard/dashboard-auth.test.ts
+++ b/dashboard/dashboard-auth.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests that dashboard password protection (HTTP Basic Auth) works correctly.
+ *
+ * Uses Hono's in-memory app.request() -- no real HTTP server needed.
+ *
+ * Run: npx tsx --test dashboard/dashboard-auth.test.ts
+ */
+
+import { test, describe, beforeEach } from "node:test";
+import { strict as assert } from "node:assert";
+
+import { createApp } from "./server.js";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const TEST_PASSWORD = "test-secret-123";
+const TEST_ENDPOINT = "/api/status";
+
+/**
+ * Encode credentials as a Basic Auth header value.
+ */
+function basicAuthHeader(username: string, password: string): string {
+  return "Basic " + Buffer.from(`${username}:${password}`).toString("base64");
+}
+
+// ============================================================================
+// TESTS
+// ============================================================================
+
+describe("dashboard password protection", () => {
+  beforeEach(() => {
+    delete process.env.DASHBOARD_PASSWORD;
+  });
+
+  test("no password set -- requests succeed without credentials", async () => {
+    const app = createApp();
+    const res = await app.request(TEST_ENDPOINT);
+    assert.equal(res.status, 200);
+  });
+
+  test("password set, no credentials -- returns 401", async () => {
+    process.env.DASHBOARD_PASSWORD = TEST_PASSWORD;
+    const app = createApp();
+    const res = await app.request(TEST_ENDPOINT);
+    assert.equal(res.status, 401);
+  });
+
+  test("password set, wrong credentials -- returns 401", async () => {
+    process.env.DASHBOARD_PASSWORD = TEST_PASSWORD;
+    const app = createApp();
+    const res = await app.request(TEST_ENDPOINT, {
+      headers: { Authorization: basicAuthHeader("admin", "wrong-password") },
+    });
+    assert.equal(res.status, 401);
+  });
+
+  test("password set, correct credentials -- returns 200", async () => {
+    process.env.DASHBOARD_PASSWORD = TEST_PASSWORD;
+    const app = createApp();
+    const res = await app.request(TEST_ENDPOINT, {
+      headers: { Authorization: basicAuthHeader("admin", TEST_PASSWORD) },
+    });
+    assert.equal(res.status, 200);
+  });
+});

--- a/dashboard/server.ts
+++ b/dashboard/server.ts
@@ -47,7 +47,7 @@ const USER_CLAUDE_MD_PATH = join(homedir(), ".claude", "CLAUDE.md");
  *
  * @returns Configured Hono app instance
  */
-function createApp(): Hono {
+export function createApp(): Hono {
   const app = new Hono();
 
   // Dashboard password protection (HTTP Basic Auth)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voicecc",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voicecc",
-      "version": "1.0.11",
+      "version": "1.1.0",
       "os": [
         "darwin",
         "linux"


### PR DESCRIPTION
Add comprehensive test suite for dashboard password protection using HTTP Basic Auth. Tests verify all authentication scenarios: open access when no password is set, 401 responses for missing/wrong credentials, and 200 responses for correct credentials. Exports createApp() function to enable testing the app in isolation without starting an HTTP server. All tests pass using node:test built-in runner.