### PR TITLE
Add OAuth token authentication for unauthenticated users

### DIFF
--- a/dashboard/routes/auth.ts
+++ b/dashboard/routes/auth.ts
@@ -14,6 +14,7 @@ import { Hono } from "hono";
 import { spawn } from "child_process";
 import { homedir } from "os";
 import { join } from "path";
+import { writeEnvKey } from "../../server/services/env.js";
 
 // ============================================================================
 // CONSTANTS
@@ -92,6 +93,26 @@ export function authRoutes(): Hono {
   const app = new Hono();
 
   app.get("/", async (c) => {
+    const authenticated = await probeClaudeAuth();
+    return c.json({ authenticated });
+  });
+
+  /**
+   * Save a Claude OAuth token to .env and re-probe authentication.
+   *
+   * @param token - The OAuth token from `claude setup-token`
+   * @returns { authenticated: boolean }
+   */
+  app.post("/token", async (c) => {
+    const { token } = await c.req.json<{ token: string }>();
+
+    if (!token || typeof token !== "string") {
+      return c.json({ error: "Token is required" }, 400);
+    }
+
+    await writeEnvKey("CLAUDE_CODE_OAUTH_TOKEN", token);
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = token;
+
     const authenticated = await probeClaudeAuth();
     return c.json({ authenticated });
   });

--- a/dashboard/routes/settings.ts
+++ b/dashboard/routes/settings.ts
@@ -14,7 +14,7 @@ import { readEnv, writeEnvFile } from "../../server/services/env.js";
 // ============================================================================
 
 /** Keys that should be masked when reading settings */
-const MASKED_KEYS = ["TWILIO_AUTH_TOKEN", "TWILIO_API_KEY_SECRET", "ELEVENLABS_API_KEY"];
+const MASKED_KEYS = ["TWILIO_AUTH_TOKEN", "TWILIO_API_KEY_SECRET", "ELEVENLABS_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"];
 
 // ============================================================================
 // ROUTES

--- a/dashboard/src/components/AuthTokenModal.tsx
+++ b/dashboard/src/components/AuthTokenModal.tsx
@@ -1,0 +1,138 @@
+/**
+ * Modal for pasting a Claude OAuth token.
+ *
+ * Guides the user to run `claude setup-token` in their terminal,
+ * then paste the resulting token. Saves it to .env via the API
+ * and re-checks authentication.
+ */
+
+import { useState } from "react";
+import { post } from "../api";
+import type { ApiError } from "../api";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+interface AuthTokenModalProps {
+  /** Callback when modal is closed */
+  onClose: () => void;
+  /** Callback after token is saved and auth is confirmed */
+  onAuthenticated: () => void;
+}
+
+// ============================================================================
+// COMPONENT
+// ============================================================================
+
+/**
+ * Modal that accepts a Claude OAuth token and saves it to .env.
+ *
+ * @param onClose - Called when the modal is dismissed
+ * @param onAuthenticated - Called after a valid token is saved
+ */
+export function AuthTokenModal({ onClose, onAuthenticated }: AuthTokenModalProps) {
+  const [token, setToken] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  /** Close modal when clicking the overlay background */
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  /** Save token to .env and re-check auth */
+  const handleSave = async () => {
+    const trimmed = token.trim();
+    if (!trimmed) return;
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const result = await post<{ authenticated: boolean }>("/api/auth/token", { token: trimmed });
+      if (result.authenticated) {
+        onAuthenticated();
+        onClose();
+      } else {
+        setError("Token was saved but authentication failed. Check that the token is valid.");
+      }
+    } catch (err) {
+      const message = (err as ApiError)?.message || "Failed to save token";
+      setError(message);
+    }
+
+    setSaving(false);
+  };
+
+  return (
+    <div className="modal-overlay visible" onClick={handleOverlayClick}>
+      <div className="modal" style={{ width: 500 }}>
+        <button className="modal-close" onClick={onClose}>&times;</button>
+        <h2>Authenticate with Claude</h2>
+
+        <div style={{ fontSize: 13, color: "var(--text-secondary)", marginBottom: 16, lineHeight: 1.5 }}>
+          <p style={{ marginBottom: 12 }}>
+            Run the following command in your terminal to generate a token:
+          </p>
+          <code style={{
+            display: "block",
+            background: "var(--bg-main)",
+            border: "1px solid var(--border-color)",
+            padding: "8px 12px",
+            fontFamily: '"SF Mono", "Fira Code", monospace',
+            fontSize: 12,
+            color: "var(--accent-color)",
+            marginBottom: 12,
+          }}>
+            claude setup-token
+          </code>
+          <p>
+            Complete the sign-in in your browser, then paste the token below.
+          </p>
+        </div>
+
+        <input
+          type="password"
+          placeholder="sk-ant-oat01-..."
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") handleSave(); }}
+          style={{
+            width: "100%",
+            padding: "8px 10px",
+            fontSize: 13,
+            fontFamily: '"SF Mono", "Fira Code", monospace',
+            background: "var(--bg-main)",
+            border: "1px solid var(--border-color)",
+            color: "var(--text-primary)",
+            boxSizing: "border-box",
+          }}
+        />
+
+        {error && (
+          <p style={{ fontSize: 12, color: "#d73a49", marginTop: 8 }}>{error}</p>
+        )}
+
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 16 }}>
+          <button
+            onClick={onClose}
+            style={{
+              background: "var(--btn-secondary-bg)",
+              color: "var(--btn-secondary-text)",
+              border: "1px solid var(--btn-secondary-border)",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving || !token.trim()}
+          >
+            {saving ? "Saving..." : "Save token"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/Layout.tsx
+++ b/dashboard/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import { TwilioStatus, BrowserCallStatus } from "../pages/Home";
 
 export interface LayoutContext {
     authStatus: boolean | null;
+    setAuthStatus: (status: boolean | null) => void;
 }
 
 interface VersionInfo {
@@ -87,7 +88,7 @@ export function Layout() {
                         </button>
                     </div>
                 )}
-                <Outlet context={{ authStatus } satisfies LayoutContext} />
+                <Outlet context={{ authStatus, setAuthStatus } satisfies LayoutContext} />
             </div>
         </div>
     );

--- a/dashboard/src/pages/Home.tsx
+++ b/dashboard/src/pages/Home.tsx
@@ -10,6 +10,7 @@ import { useState, useEffect } from "react";
 import { useOutletContext, Link } from "react-router-dom";
 import { get } from "../api";
 import type { LayoutContext } from "../components/Layout";
+import { AuthTokenModal } from "../components/AuthTokenModal";
 
 // ============================================================================
 // TYPES
@@ -39,9 +40,10 @@ interface McpServerEntry {
 }
 
 export function Home() {
-  const { authStatus } = useOutletContext<LayoutContext>();
+  const { authStatus, setAuthStatus } = useOutletContext<LayoutContext>();
   const [browserCallRunning, setBrowserCallRunning] = useState<boolean | null>(null);
   const [mcpServers, setMcpServers] = useState<McpServerEntry[] | null>(null);
+  const [showTokenModal, setShowTokenModal] = useState(false);
 
   useEffect(() => {
     get<BrowserCallStatus>("/api/browser-call/status")
@@ -91,7 +93,19 @@ export function Home() {
             </span>
           </div>
 
+          {authStatus === false && (
+            <div className="settings-actions">
+              <button onClick={() => setShowTokenModal(true)}>Set up authentication</button>
+            </div>
+          )}
         </div>
+
+        {showTokenModal && (
+          <AuthTokenModal
+            onClose={() => setShowTokenModal(false)}
+            onAuthenticated={() => setAuthStatus(true)}
+          />
+        )}
 
         <div className="settings-panel">
           <h2 style={{ fontSize: 16, fontWeight: 600, color: "var(--text-primary)", marginBottom: 4 }}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voicecc",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voicecc",
-      "version": "1.0.11",
+      "version": "1.1.0",
       "os": [
         "darwin",
         "linux"


### PR DESCRIPTION
## Summary

Adds an alternative authentication flow for users who are not logged in to Claude Code. Unauthenticated users can now run `claude setup-token` in their terminal and paste the resulting OAuth token into a modal dialog. The token is saved to `.env` as `CLAUDE_CODE_OAUTH_TOKEN` and authentication is immediately re-checked.

## What changed

- New `POST /api/auth/token` endpoint accepts an OAuth token and saves it to `.env`
- New `AuthTokenModal` component guides users through the setup process
- Home page displays a "Set up authentication" button when `authStatus === false`
- Layout context now exposes `setAuthStatus` for updating authentication state
- `CLAUDE_CODE_OAUTH_TOKEN` is added to masked keys to prevent leaking secrets via the settings API

## Why

This provides an alternative to `claude login` that works in headless/automated environments and enables token-based authentication for the Claude subscription. Users who are not logged in now have actionable guidance on how to authenticate.

## How it works

When a user is not authenticated and clicks "Set up authentication", the modal opens with instructions to run `claude setup-token` in their terminal. After completing the OAuth flow in their browser, they paste the token into the modal. The token is sent to the backend, saved to `.env`, and authentication is re-probed. On success, the modal closes and the Home page updates to show "Claude Code is authenticated".

## How to test

1. Ensure you are not logged in to Claude Code (delete credentials if needed)
2. Open the dashboard and check the Home page - you should see "Claude Code is not authenticated" with a red status indicator
3. Click "Set up authentication"
4. Run `claude setup-token` in another terminal and complete the OAuth flow
5. Paste the resulting token into the modal
6. Verify the authentication status updates to green and the modal closes