### PR TITLE
Fix tunnel URL not displayed on startup

### DIFF
--- a/bin/voicecc.js
+++ b/bin/voicecc.js
@@ -543,6 +543,16 @@ if (isRunning()) {
 // Start the daemon
 startDaemon();
 
-// Wait briefly for server to write status.json, then show info
-await new Promise((resolve) => setTimeout(resolve, 3000));
+// Poll for status.json until the server is ready
+const tunnelEnabled = readFileSync(ENV_PATH, "utf-8").includes("TUNNEL_ENABLED=true");
+const MAX_WAIT_MS = tunnelEnabled ? 30000 : 10000;
+const POLL_INTERVAL_MS = 500;
+const startTime = Date.now();
+
+while (Date.now() - startTime < MAX_WAIT_MS) {
+  await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  const status = readStatus();
+  if (status && (!tunnelEnabled || status.tunnelUrl)) break;
+}
+
 showInfo();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voicecc",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voicecc",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "os": [
         "darwin",
         "linux"


### PR DESCRIPTION
## What

When enabling the tunnel during setup, the CLI startup banner was not showing the tunnel URL. Instead, it displayed a generic 'Server is starting up...' message. The dashboard URL was also missing in many cases.

## Why

The CLI was waiting a fixed 3 seconds for the server to write its status to ~/.voicecc/status.json, but Cloudflare tunnel startup often takes longer than that, particularly on first run. This timing mismatch meant the status file was not ready when the CLI tried to read it.

## How

Replace the fixed timeout with an intelligent polling strategy:

- Poll up to 30 seconds when tunnel is enabled (checking for both dashboard port and tunnel URL)
- Poll up to 10 seconds when tunnel is disabled (checking for just the dashboard port)
- Read TUNNEL_ENABLED from .env to determine the expected startup time
- Stop polling early once the expected status fields are available

This ensures the CLI always waits long enough for the server to finish startup and write complete status information.

## How to test

1. Enable tunnel during setup
2. Run `voicecc` to start the daemon
3. Verify the startup banner displays both the dashboard URL and tunnel URL with no delay
4. Disable tunnel in settings, restart, and verify it still displays quickly