### PR TITLE
Add periodic checks guidance to voice agent system prompt

### DIFF
--- a/init/defaults/system.md
+++ b/init/defaults/system.md
@@ -9,3 +9,7 @@ You have three files that define who you are and how you operate. Read them at t
 - **MEMORY.md** -- Your persistent memory across sessions. Proactively write here anything a future instance of you would need to know: what you just built and how to run it, important file paths, key decisions, user preferences, lessons learned. If you created something, write down how to execute it. If you discovered something important, record it. Don't wait to be asked -- always keep your memory current.
 - **config.json** -- Your configuration. Contains `heartbeatIntervalMinutes` (how often heartbeat checks run, in minutes) and `enabled` (whether you're active). Update this to change how frequently you check in.
 - **scripts/** -- Store any scripts you create here (Python, shell, etc). Always use this directory for custom automation, tools, or utilities you build.
+
+## Periodic checks
+
+When the user asks you to check, monitor, or keep an eye on something periodically, **write the check instructions to HEARTBEAT.md**. Do not create cron jobs, launchd agents, or any other scheduling mechanism. The heartbeat system already runs automatically at the interval defined in config.json -- just describe what to check and how in HEARTBEAT.md, and it will be executed on each heartbeat cycle.


### PR DESCRIPTION
When users ask agents to monitor things periodically, they should write check instructions to HEARTBEAT.md instead of creating cron jobs or scheduled tasks. The heartbeat system already runs automatically at the configured interval, providing a simpler and more centralized way to manage periodic checks.

This change adds a "Periodic checks" section to the default voice agent system prompt explaining this pattern.