### PR TITLE
Add agent import/export via zip archives

### DIFF
--- a/dashboard/routes/agents.ts
+++ b/dashboard/routes/agents.ts
@@ -17,6 +17,8 @@ import {
   createAgent,
   deleteAgent,
   updateAgentConfig,
+  exportAgent,
+  importAgent,
 } from "../../server/services/agent-store.js";
 import type { AgentConfig } from "../../server/services/agent-store.js";
 import { getHeartbeatStatus, initiateAgentCall } from "../../server/services/heartbeat.js";
@@ -33,17 +35,62 @@ import { getHeartbeatStatus, initiateAgentCall } from "../../server/services/hea
 export function agentsRoutes(): Hono {
   const app = new Hono();
 
-  // /heartbeat/status MUST be registered before /:id to avoid route conflict
+  // /heartbeat/status and /import MUST be registered before /:id to avoid route conflict
   /** Get last heartbeat result per agent */
   app.get("/heartbeat/status", (c) => {
     const status = getHeartbeatStatus();
     return c.json(status);
   });
 
+  /** Import an agent from a zip upload */
+  app.post("/import", async (c) => {
+    try {
+      console.log("[import] Parsing body...");
+      const body = await c.req.parseBody();
+      const file = body["file"];
+      const id = body["id"];
+      console.log("[import] file type:", typeof file, file instanceof File ? "File" : file?.constructor?.name);
+      console.log("[import] id:", id);
+
+      if (!file || !(file instanceof File)) {
+        return c.json({ error: "Missing 'file' field (zip archive)" }, 400);
+      }
+      if (!id || typeof id !== "string") {
+        return c.json({ error: "Missing 'id' field (new agent ID)" }, 400);
+      }
+
+      const arrayBuffer = await file.arrayBuffer();
+      const buffer = Buffer.from(arrayBuffer);
+      console.log("[import] Buffer size:", buffer.length);
+      await importAgent(id, buffer);
+      console.log("[import] Success, agent:", id);
+      return c.json({ success: true, id });
+    } catch (err) {
+      console.error("[import] Error:", err);
+      return c.json({ error: (err as Error).message }, 400);
+    }
+  });
+
   /** List all agents with summary info */
   app.get("/", async (c) => {
     const agents = await listAgents();
     return c.json(agents);
+  });
+
+  /** Export an agent as a zip download */
+  app.get("/:id/export", async (c) => {
+    const id = c.req.param("id");
+    try {
+      const zipBuffer = await exportAgent(id);
+      return new Response(new Uint8Array(zipBuffer), {
+        headers: {
+          "Content-Type": "application/zip",
+          "Content-Disposition": `attachment; filename="${id}.zip"`,
+        },
+      });
+    } catch (err) {
+      return c.json({ error: (err as Error).message }, 404);
+    }
   });
 
   /** Get full agent data by ID */

--- a/dashboard/src/pages/AgentDetail.tsx
+++ b/dashboard/src/pages/AgentDetail.tsx
@@ -176,6 +176,25 @@ export function AgentDetail() {
           <h2 style={{ margin: 0, fontSize: 18, fontWeight: 600, color: "var(--text-primary)" }}>{agent.id}</h2>
         </div>
         <div style={{ display: "flex", gap: 8 }}>
+          <a
+            href={`/api/agents/${id}/export`}
+            download={`${id}.zip`}
+            style={{
+              padding: "6px 14px",
+              background: "var(--bg-main)",
+              color: "var(--text-primary)",
+              border: "1px solid var(--border-color)",
+              borderRadius: 0,
+              fontWeight: 500,
+              fontSize: 13,
+              cursor: "pointer",
+              textDecoration: "none",
+              display: "inline-flex",
+              alignItems: "center",
+            }}
+          >
+            Export
+          </a>
           <button
             onClick={handleCall}
             disabled={calling}

--- a/dashboard/src/pages/Agents.tsx
+++ b/dashboard/src/pages/Agents.tsx
@@ -44,6 +44,7 @@ export function Agents() {
   const [form, setForm] = useState<CreateAgentForm>(INITIAL_FORM);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [importing, setImporting] = useState(false);
 
   // ============================================================================
   // EVENT HANDLERS
@@ -84,6 +85,37 @@ export function Agents() {
     setError(null);
   };
 
+  /**
+   * Import an agent from a zip file.
+   * Prompts for a new agent ID, uploads the zip via FormData.
+   */
+  const handleImport = async (file: File) => {
+    const agentId = window.prompt("Enter an ID for the imported agent:", file.name.replace(/\.zip$/i, ""));
+    if (!agentId) return;
+
+    setImporting(true);
+    setError(null);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("id", agentId);
+
+      const res = await fetch("/api/agents/import", { method: "POST", body: formData });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({ error: "Import failed" }));
+        throw new Error(data.error || "Import failed");
+      }
+
+      const updated = await get<AgentSummary[]>("/api/agents");
+      setAgents(updated);
+    } catch (err: unknown) {
+      const message = (err as { message?: string })?.message || "Failed to import agent";
+      setError(message);
+    } finally {
+      setImporting(false);
+    }
+  };
+
   // ============================================================================
   // RENDER
   // ============================================================================
@@ -94,23 +126,58 @@ export function Agents() {
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "24px 32px 16px", borderBottom: "1px solid var(--border-color)", flexShrink: 0 }}>
         <h2 style={{ margin: 0, fontSize: 18, fontWeight: 600, color: "var(--text-primary)" }}>Agents</h2>
         {!showForm && (
-          <button
-            onClick={() => setShowForm(true)}
-            style={{
-              padding: "6px 14px",
-              background: "var(--btn-primary-bg)",
-              color: "var(--btn-primary-text)",
-              border: "none",
-              borderRadius: 0,
-              fontWeight: 500,
-              fontSize: 13,
-              cursor: "pointer",
-            }}
-          >
-            Create Agent
-          </button>
+          <div style={{ display: "flex", gap: 8 }}>
+            <label
+              style={{
+                padding: "6px 14px",
+                background: "var(--bg-main)",
+                color: "var(--text-primary)",
+                border: "1px solid var(--border-color)",
+                borderRadius: 0,
+                fontWeight: 500,
+                fontSize: 13,
+                cursor: importing ? "not-allowed" : "pointer",
+                opacity: importing ? 0.6 : 1,
+              }}
+            >
+              {importing ? "Importing..." : "Import"}
+              <input
+                type="file"
+                accept=".zip"
+                style={{ display: "none" }}
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) handleImport(file);
+                  e.target.value = "";
+                }}
+                disabled={importing}
+              />
+            </label>
+            <button
+              onClick={() => setShowForm(true)}
+              style={{
+                padding: "6px 14px",
+                background: "var(--btn-primary-bg)",
+                color: "var(--btn-primary-text)",
+                border: "none",
+                borderRadius: 0,
+                fontWeight: 500,
+                fontSize: 13,
+                cursor: "pointer",
+              }}
+            >
+              Create Agent
+            </button>
+          </div>
         )}
       </div>
+
+      {/* Import error banner (shown outside the create form) */}
+      {error && !showForm && (
+        <div style={{ margin: "16px 32px 0", padding: "8px 10px", fontSize: 12, color: "#d73a49", background: "var(--bg-tertiary)", borderRadius: 6, border: "1px solid #d73a49" }}>
+          {error}
+        </div>
+      )}
 
       {/* Scrollable Content */}
       <div style={{ flex: 1, overflowY: "auto", padding: "48px 64px" }}>

--- a/server/services/agent-store.ts
+++ b/server/services/agent-store.ts
@@ -16,6 +16,11 @@ import { readFile, writeFile, mkdir, readdir, rm, access } from "fs/promises";
 import { dirname, join } from "path";
 import { homedir } from "os";
 import { fileURLToPath } from "url";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { tmpdir } from "os";
+
+const execFileAsync = promisify(execFile);
 
 // ============================================================================
 // CONSTANTS
@@ -203,6 +208,72 @@ export async function updateAgentConfig(
   const updated: AgentConfig = { ...existing, ...patch };
   await writeFile(configPath, JSON.stringify(updated, null, 2), "utf-8");
   return updated;
+}
+
+// ============================================================================
+// IMPORT / EXPORT
+// ============================================================================
+
+/**
+ * Export an agent's entire directory as a zip buffer.
+ * Includes all files (SOUL.md, MEMORY.md, HEARTBEAT.md, config.json, and any
+ * additional files the agent may have created).
+ *
+ * @param id - Agent identifier
+ * @returns Buffer containing the zip archive
+ */
+export async function exportAgent(id: string): Promise<Buffer> {
+  const agentDir = join(AGENTS_DIR, id);
+  await assertAgentExists(agentDir, id);
+
+  const zipPath = join(tmpdir(), `agent-export-${id}-${Date.now()}.zip`);
+  try {
+    await execFileAsync("zip", ["-r", zipPath, "."], { cwd: agentDir });
+    const buf = await readFile(zipPath);
+    return buf;
+  } finally {
+    await rm(zipPath, { force: true }).catch(() => {});
+  }
+}
+
+/**
+ * Import an agent from a zip buffer. Creates a new agent directory and extracts
+ * the zip contents into it. The zip must contain a config.json at the root level.
+ *
+ * @param id - New agent identifier
+ * @param zipBuffer - Buffer containing the zip archive
+ */
+export async function importAgent(id: string, zipBuffer: Buffer): Promise<void> {
+  validateAgentId(id);
+
+  const agentDir = join(AGENTS_DIR, id);
+  const dirExists = await access(agentDir).then(() => true).catch(() => false);
+  if (dirExists) throw new Error(`Agent "${id}" already exists`);
+
+  // Write zip to temp file, extract to agent dir
+  const zipPath = join(tmpdir(), `agent-import-${id}-${Date.now()}.zip`);
+  try {
+    await writeFile(zipPath, zipBuffer);
+    await mkdir(agentDir, { recursive: true });
+    await execFileAsync("unzip", ["-o", zipPath, "-d", agentDir]);
+
+    // Validate the zip contained a config.json
+    const hasConfig = await access(join(agentDir, "config.json")).then(() => true).catch(() => false);
+    if (!hasConfig) {
+      await rm(agentDir, { recursive: true });
+      throw new Error("Invalid agent archive: missing config.json");
+    }
+  } catch (err) {
+    // Clean up on failure (if dir was created but extraction failed)
+    const exists = await access(agentDir).then(() => true).catch(() => false);
+    if (exists) {
+      const hasConfig = await access(join(agentDir, "config.json")).then(() => true).catch(() => false);
+      if (!hasConfig) await rm(agentDir, { recursive: true });
+    }
+    throw err;
+  } finally {
+    await rm(zipPath, { force: true }).catch(() => {});
+  }
 }
 
 // ============================================================================


### PR DESCRIPTION

## Summary

Added bidirectional import/export functionality for agents. Users can export any agent's entire directory (all files including generated CSVs, scripts, etc.) as a zip file and import agents from zips with a custom ID. Backend uses native `zip`/`unzip` commands with proper cleanup and validation.

## Changes

- **Backend** (`agent-store.ts`): `exportAgent()` zips the full directory; `importAgent()` extracts and validates
- **Routes** (`agents.ts`): `GET /:id/export` for download, `POST /import` for multipart upload
- **Frontend** (`AgentDetail.tsx`): Export button downloads agent as `.zip`
- **Frontend** (`Agents.tsx`): Import button opens file picker, prompts for agent ID, handles errors

## Test Plan

- Export an agent and verify the zip contains all files
- Import the zip and confirm agent is created with new ID
- Test error handling for missing `config.json` in zip
- Verify both buttons are properly styled and functional
